### PR TITLE
Twig font-locking

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -788,7 +788,7 @@ With the value 2 blocks like <?php for (): ?> stay on the left (no indentation).
      ((string= sub2 "{{")
       (setq regexp "\"\\|'"
             props '(server-engine django face nil)
-            keywords web-mode-uel-font-lock-keywords)
+            keywords web-mode-twig-font-lock-keywords)
       )
 
      ((string= sub2 "{%")
@@ -2911,6 +2911,14 @@ point is at the beginning of the line."
    (cons (concat "[% ]\\(" web-mode-django-keywords "\\)[ %]") '(1 'web-mode-keyword-face t t))
    '("\\<\\(\\sw+\\)[ ]?(" 1 'web-mode-function-name-face)
    ))
+
+(defconst web-mode-twig-font-lock-keywords
+  (append 
+   web-mode-django-font-lock-keywords
+   (list
+    '("{{\\|}}" 0 'web-mode-preprocessor-face)
+    '("[[:alpha:]_]" 0 'web-mode-variable-name-face)   
+    )))
 
 (defconst web-mode-ctemplate-font-lock-keywords
   (list


### PR DESCRIPTION
For some reason the keywords were being set to
`web-mode-uel-font-lock-keywords` when encountering `{{` tags.  As far
as I can tell, UEL does not use `{{` at all.  This was causing
`}` (used by twig in array definitions) to be erroneously highlighted.

Example:

``` html
        <a href="{{ path('frontend_members_view', { 'username': username }) }}">
```

The first `}` after `username` would be highlighted.

The `web-mode-django-font-lock-keywords` were not completely
appropriate either.  This new set of keywords is a better fit for twig
and provides a place for further customization.
