### PR TITLE
Colorize CSS foregrounds so that they are always readable

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -1404,6 +1404,15 @@ With the value 2 blocks like <?php for (): ?> stay on the left (no indentation).
 
   )
 
+(defun web-mode-colorize-foreground (color)
+  "Colorize foreground based on background luminance."
+  (let* ((values (x-color-values color))
+	 (r (car values))
+	 (g (cadr values))
+	 (b (car (cdr (cdr values)))))
+    (if (> 128.0 (floor (+ (* .3 r) (* .59 g) (* .11 b)) 256))
+	"white" "black")))
+
 (defun web-mode-colorize (beg end)
   "Colorize CSS colors."
   (let (str plist len)
@@ -1411,7 +1420,7 @@ With the value 2 blocks like <?php for (): ?> stay on the left (no indentation).
     (setq len (length str))
     (cond
      ((string= (substring str 0 1) "#")
-      (setq plist (list :background str))
+      (setq plist (list :background str :foreground (web-mode-colorize-foreground str)))
       (put-text-property beg end 'face plist)
       )
      ((string= (substring str 0 4) "rgb(")
@@ -1419,7 +1428,7 @@ With the value 2 blocks like <?php for (): ?> stay on the left (no indentation).
                         (string-to-number (match-string-no-properties 1))
                         (string-to-number (match-string-no-properties 2))
                         (string-to-number (match-string-no-properties 3))))
-      (setq plist (list :background str))
+      (setq plist (list :background str :foreground (web-mode-colorize-foreground str)))
       (put-text-property beg end 'face plist)
       )
      )


### PR DESCRIPTION
Preview of this change:

![colorize](https://f.cloud.github.com/assets/129148/284277/c1451070-91da-11e2-9b88-54a1074dc224.png)
