### PR TITLE
web-mode-comment-or-uncomment fix

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -4262,10 +4262,12 @@ Must be used in conjunction with web-mode-enable-block-face."
 (defun web-mode-comment-or-uncomment (&optional pos)
   "Comment or uncomment line(s), block or region at POS."
   (interactive)
-  (unless pos (setq pos (if mark-active (region-beginning) (point))))
-  (if (web-mode-is-comment)
-      (web-mode-uncomment pos)
-    (web-mode-comment pos))
+  (save-excursion
+    (re-search-forward "[^[:space:]]" (line-end-position) t)
+    (unless pos (setq pos (if mark-active (region-beginning) (point))))
+    (if (web-mode-is-comment)
+	(web-mode-uncomment pos)
+      (web-mode-comment pos)))
   (web-mode-scan-region (point-min) (point-max)))
 
 (defun web-mode-comment (pos)


### PR DESCRIPTION
Hi. Lets look at following snippet (underscore is cursor position):

``` html
<div>
_  <!-- <p>foo</p> -->
<div>
```

Calling web-mode-comment-or-uncomment function in such case resulted in commenting out your own comment twice (and not uncommenting existing comment):

``` html
<div>
_  <!-- <!-- <p>foo</p> --> -->
<div>
```

I don't think it's the most desirable behaviour.
Calling web-mode-comment-or-uncomment function in front of a comment - uncomments existing comment after applying the this patch.
Thanks.
