### PR TITLE
fix yasnippet exit hook

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -1728,13 +1728,14 @@ Must be used in conjunction with web-mode-enable-block-face."
 ;;  (when (boundp 'rainbow-mode) (rainbow-mode -1))
 
   (web-mode-guess-engine-and-content-type)
-  (web-mode-scan-buffer)
+  (web-mode-scan-buffer)
 ;;  (message "%S" web-mode-extra-snippets)
   )
 
 (defun web-mode-yasnippet-exit-hook ()
   "Yasnippet exit hook"
-  (web-mode-buffer-refresh))
+  (web-mode-scan-region yas-snippet-beg yas-snippet-end)
+  (indent-region yas-snippet-beg yas-snippet-end))
 
 (defun web-mode-forward-sexp (&optional arg)
   "Move forward."


### PR DESCRIPTION
This will preserve the intent of issue #51 (highlight and indent after yasnippet insert) without clobbering any custom/manual indention in the buffer due to the full-buffer reindent.  

This in turn resolves #122, without requiring users to remove the hook (and revert to non-indenting/highlighting snippets) in their emacs config.
