### PR TITLE
Correct regexp for font locking Ruby's namespace resolution operator.

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -1489,7 +1489,7 @@ Must be used in conjunction with web-mode-enable-block-face."
 (defvar web-mode-erb-font-lock-keywords
   (list
    '("-?%>\\|^%\\|<%[=-]?" 0 'web-mode-preprocessor-face)
-   '("\\(:[[:alnum:]_]+\\)" 1 'web-mode-symbol-face)
+   '("[^:]\\(:[[:alnum:]_]+\\)" 1 'web-mode-symbol-face)
    '("\\([[:alnum:]_]+:\\)[ ]+" 1 'web-mode-symbol-face)
    (cons (concat "\\<\\(" web-mode-erb-builtins "\\)\\>")
          '(0 'web-mode-builtin-face))


### PR DESCRIPTION
Fixes the case for example for `Admin::User`. Where `:User` had `web-mode-symbol-face` applied.
