### PR TITLE
add support for functions in web-mode-engines-alist

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -2031,8 +2031,13 @@ Must be used in conjunction with web-mode-enable-block-face."
     (when (boundp 'web-mode-engines-alist)
       (setq found nil)
       (dolist (elt web-mode-engines-alist)
-        (when (string-match-p (cdr elt) buff-name)
-          (setq web-mode-engine (car elt)))
+        (cond
+         ((stringp (cdr elt))
+          (when (string-match-p (cdr elt) buff-name)
+            (setq web-mode-engine (car elt))))
+         ((functionp (cdr elt))
+          (when (funcall (cdr elt))
+            (setq web-mode-engine (car elt)))))
         )
       )
     (unless web-mode-engine


### PR DESCRIPTION
Currently, the user must pass a regexp to check against the buffer name
for setting the web-mode engine. However, sometimes it's convenient to
use a function instead. Add support for using a function in addition to
the current regexp method.

Example usage:

```
(defun my-current-buffer-django-p ()
  (save-excursion
    (search-forward-regexp "{% base\\|{% if\\|{% include\\|{% block"
                           nil
                           t)))

(setq web-mode-engines-alist
      '(("django" . "\\.djhtml")
        ("django" . my-current-buffer-django-p)))
```
