### PR TITLE
Checking that web-mode-active-block-regexp actually exists

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -4549,7 +4549,8 @@ Must be used in conjunction with web-mode-enable-block-face."
   (save-excursion
     (let (ctrl state)
       (goto-char pos) ;;(message "pos=%S" pos)
-      (when (looking-at web-mode-active-block-regexp)
+      (when (and (stringp 'web-mode-active-block-regexp)
+                 (looking-at web-mode-active-block-regexp))
 
         (cond
 


### PR DESCRIPTION
When using angular (or any other web engine that doesn't use code blocks), line indenting can fail with the following error:

```
web-mode-is-active-block: Wrong type argument: stringp, nil
```

Checking if web-mode-active-block-regexp exists fixes this.
