### PR TITLE
Make menu action match menu title

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -1830,7 +1830,7 @@ Must be used in conjunction with web-mode-enable-block-face."
     (define-key map [menu-bar wm tag tag-pre] '(menu-item "Previous" web-mode-tag-previous))
     (define-key map [menu-bar wm tag tag-nex] '(menu-item "Next" web-mode-tag-next))
     (define-key map [menu-bar wm tag tag-mat] '(menu-item "Match" web-mode-tag-match))
-    (define-key map [menu-bar wm tag tag-end] '(menu-item "End" web-mode-tag-beginning))
+    (define-key map [menu-bar wm tag tag-end] '(menu-item "End" web-mode-tag-end))
     (define-key map [menu-bar wm tag tag-beg] '(menu-item "Beginning" web-mode-tag-beginning))
 
     (define-key map [menu-bar wm elt elt-wra] '(menu-item "Wrap" web-mode-element-wrap))


### PR DESCRIPTION
web-mode-tag-beginning was accidentally repeated in the menu definition.
