### PR TITLE
Indent "^\\." to match first "." in prev-line.

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -5611,10 +5611,8 @@ Must be used in conjunction with web-mode-enable-block-face."
           )
 
          ((and (string= language "javascript") (eq ?\. first-char))
-          (when (string-match-p "[[:alnum:][:blank:]]+\\.[[:alpha:]]" prev-line)
-            (let ((new-offset (+ prev-indentation (search "." prev-line))))
-              (setq offset new-offset)
-              (message (number-to-string new-offset)))))
+           (let ((i (string-match-p "\\." prev-line)))
+             (when i (setq offset (+ prev-indentation i)))))
 
          ((and (member first-char '(?\? ?\. ?\:))
                (not (string= language "erb")))


### PR DESCRIPTION
I think it makes sense to indent to the first period in the
previous line as default behavior, especially for working with code like
this where periods can occur in sub-expressions:

```
innerlabels.attr("x", function(d){ return d.x + width - 4 })
           .attr("class", "vertex-contents")
```
