### PR TITLE
Fixed mojolicious support

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -639,7 +639,7 @@ Must be used in conjunction with web-mode-enable-block-face."
     ("lsp"              . "\\.lsp\\'")
     ("mako"             . "\\.mako?\\'")
     ("mason"            . "\\.mas\\'")
-    ("mojolicious"      . "mojolicious\\|\\.epl\\'")
+    ("mojolicious"      . "mojolicious\\|\\.epl\\|\\.html\\.ep\\'")
     ("mustache"         . "\\.mustache\\'")
     ("php"              . "\\.\\(php\\|ctp\\|psp\\|inc\\)\\'")
     ("python"           . "\\.pml\\'")


### PR DESCRIPTION
Nowdays mojolicious apps mostly use .html.ep extension for template files.
