### PR TITLE
Update references to web-mode-dom-normalize

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -1630,7 +1630,7 @@ Must be used in conjunction with web-mode-enable-block-face."
     (define-key map [menu-bar wm dom dom-ent] '(menu-item "Replace HTML entities" web-mode-dom-entities-replace))
     (define-key map [menu-bar wm dom dom-quo] '(menu-item "Replace dumb quotes" web-mode-dom-quotes-replace))
     (define-key map [menu-bar wm dom dom-apo] '(menu-item "Replace apostrophes" web-mode-dom-apostrophes-replace))
-    (define-key map [menu-bar wm dom dom-nor] '(menu-item "Normalise" web-mode-dom-normalize))
+    (define-key map [menu-bar wm dom dom-nor] '(menu-item "Normalise" web-mode-buffer-normalize))
 
     (define-key map [menu-bar wm blk blk-sel] '(menu-item "Select" web-mode-block-select))
     (define-key map [menu-bar wm blk blk-pre] '(menu-item "Previous" web-mode-block-previous))
@@ -1697,7 +1697,7 @@ Must be used in conjunction with web-mode-enable-block-face."
     (define-key map (kbd "C-c C-b s") 'web-mode-block-select)
 
     (define-key map (kbd "C-c C-d a") 'web-mode-dom-apostrophes-replace)
-    (define-key map (kbd "C-c C-d n") 'web-mode-dom-normalize)
+    (define-key map (kbd "C-c C-d n") 'web-mode-buffer-normalize)
     (define-key map (kbd "C-c C-d d") 'web-mode-dom-errors-show)
     (define-key map (kbd "C-c C-d e") 'web-mode-dom-entities-replace)
     (define-key map (kbd "C-c C-d q") 'web-mode-dom-quotes-replace)


### PR DESCRIPTION
I tried to use `C-c C-d n` to re-indent a buffer, per the docs on web-mode.org, and got an error for an undefined function.

This should fix it.
