### PR TITLE
Fix empty ac-sources in web-mode

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -10039,10 +10039,11 @@ Pos should be in a tag."
   (if (equal major-mode 'web-mode)
       (progn
         (run-hooks 'web-mode-before-auto-complete-hooks)
-        (let ((new-web-mode-ac-sources
-               (assoc (web-mode-language-at-pos)
-                      web-mode-ac-sources-alist)))
-          (setq ac-sources (cdr new-web-mode-ac-sources))))))
+        (when web-mode-ac-sources-alist
+         (let ((new-web-mode-ac-sources
+                (assoc (web-mode-language-at-pos)
+                       web-mode-ac-sources-alist)))
+           (setq ac-sources (cdr new-web-mode-ac-sources)))))))
 
 ;;---- MINOR MODE ADDONS -------------------------------------------------------
 


### PR DESCRIPTION
When `web-mode-ac-sources-alist' is nil, ac-sources will always be set
to nil when auto-complete starts. We should only set ac-sources when
`web-mode-ac-sources-alist' is defined.
