### PR TITLE
Move `(provide 'web-mode)` so `quelpa` can build the package.

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -10977,8 +10977,8 @@ Pos should be in a tag."
     (recenter)
   ))
 
-;;; web-mode.el ends here
 (provide 'web-mode)
+;;; web-mode.el ends here
 
 ;; Local Variables:
 ;; coding: utf-8


### PR DESCRIPTION
Putting the provide statement after the "ends here" comment made `quelpa` cut
the provide, resulting in "feature not provided" errors. When the provide comes
before the comment, the build works properly.
