### PR TITLE
fix comment-or-uncomment to work with marked region

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -7666,8 +7666,9 @@ Pos should be in a tag."
   (interactive)
 ;;  (message "%S" (point))
   (save-excursion
-    (unless mark-active
-      (skip-chars-forward "[:space:]" (line-end-position)))
+    (if (and mark-active (eq (point) (region-end)))
+        (exchange-point-and-mark))
+    (skip-chars-forward "[:space:]" (line-end-position))
     (if (or (eq (get-text-property (point) 'tag-type) 'comment)
             (eq (get-text-property (point) 'block-token) 'comment)
             (eq (get-text-property (point) 'part-token) 'comment))

--- a/web-mode.el
+++ b/web-mode.el
@@ -7668,9 +7668,9 @@ Pos should be in a tag."
   (save-excursion
     (unless mark-active
       (skip-chars-forward "[:space:]" (line-end-position)))
-    (if (or (eq (get-text-property (region-beginning) 'tag-type) 'comment)
-            (eq (get-text-property (region-beginning) 'block-token) 'comment)
-            (eq (get-text-property (region-beginning) 'part-token) 'comment))
+    (if (or (eq (get-text-property (point) 'tag-type) 'comment)
+            (eq (get-text-property (point) 'block-token) 'comment)
+            (eq (get-text-property (point) 'part-token) 'comment))
 	(web-mode-uncomment (point))
       (web-mode-comment (point)))))
 

--- a/web-mode.el
+++ b/web-mode.el
@@ -7668,9 +7668,9 @@ Pos should be in a tag."
   (save-excursion
     (unless mark-active
       (skip-chars-forward "[:space:]" (line-end-position)))
-    (if (or (eq (get-text-property (point) 'tag-type) 'comment)
-            (eq (get-text-property (point) 'block-token) 'comment)
-            (eq (get-text-property (point) 'part-token) 'comment))
+    (if (or (eq (get-text-property (region-beginning) 'tag-type) 'comment)
+            (eq (get-text-property (region-beginning) 'block-token) 'comment)
+            (eq (get-text-property (region-beginning) 'part-token) 'comment))
 	(web-mode-uncomment (point))
       (web-mode-comment (point)))))
 


### PR DESCRIPTION
When I tried to run web-mode-comment-or-uncomment with the marked region, based on my cursor position it fails to uncomment properly. For example,

![image](https://cloud.githubusercontent.com/assets/4635504/5895577/dc3f577a-a55e-11e4-99a1-10b42195d54c.png)

If my point is above of </div> position, it comments again rather than uncomment. I guess the get-text-property checking fails since (text-properties (point)) is nil at the position. I would appreciate if you can take a look whether this makes sense. Although the change works for me, since I'm not good at elips, my solution could be bad. 