### PR TITLE
Support for web-mode-attribute-kill

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -1915,7 +1915,7 @@ the environment as needed for ac-sources, right before they're used.")
     (define-key map [menu-bar wm attr attr-end] '(menu-item "End" web-mode-attribute-end))
     (define-key map [menu-bar wm attr attr-beg] '(menu-item "Beginning" web-mode-attribute-beginning))
     (define-key map [menu-bar wm attr attr-sel] '(menu-item "Select" web-mode-attribute-select))
-    (define-key map [menu-bar wm attr attr-kil] '(menu-item "Select" web-mode-attribute-kill))
+    (define-key map [menu-bar wm attr attr-kil] '(menu-item "Kill" web-mode-attribute-kill))
     (define-key map [menu-bar wm attr attr-nex] '(menu-item "Next" web-mode-attribute-next))
     (define-key map [menu-bar wm attr attr-tra] '(menu-item "Transpose" web-mode-attribute-transpose))
 

--- a/web-mode.el
+++ b/web-mode.el
@@ -1915,6 +1915,7 @@ the environment as needed for ac-sources, right before they're used.")
     (define-key map [menu-bar wm attr attr-end] '(menu-item "End" web-mode-attribute-end))
     (define-key map [menu-bar wm attr attr-beg] '(menu-item "Beginning" web-mode-attribute-beginning))
     (define-key map [menu-bar wm attr attr-sel] '(menu-item "Select" web-mode-attribute-select))
+    (define-key map [menu-bar wm attr attr-kil] '(menu-item "Select" web-mode-attribute-kill))
     (define-key map [menu-bar wm attr attr-nex] '(menu-item "Next" web-mode-attribute-next))
     (define-key map [menu-bar wm attr attr-tra] '(menu-item "Transpose" web-mode-attribute-transpose))
 
@@ -1960,6 +1961,7 @@ the environment as needed for ac-sources, right before they're used.")
     (define-key map (kbd "C-c C-a e") 'web-mode-attribute-end)
     (define-key map (kbd "C-c C-a i") 'web-mode-attribute-insert)
     (define-key map (kbd "C-c C-a s") 'web-mode-attribute-select)
+    (define-key map (kbd "C-c C-a k") 'web-mode-attribute-kill)
     (define-key map (kbd "C-c C-a t") 'web-mode-attribute-transpose)
     (define-key map (kbd "C-c C-a n") 'web-mode-attribute-next)
 
@@ -8736,7 +8738,7 @@ Pos should be in a tag."
                (> tag-end next-end))
       (setq attr-beg (web-mode-attribute-beginning-position pos)
             attr-end (web-mode-attribute-end-position pos))
-;;      (message "%S %S - %S %S" attr-beg attr-end next-beg next-end)
+      ;;      (message "%S %S - %S %S" attr-beg attr-end next-beg next-end)
       (transpose-regions attr-beg (1+ attr-end) next-beg (1+ next-end))
       )))
 
@@ -8752,6 +8754,13 @@ Pos should be in a tag."
     (web-mode-attribute-end)
     (point)
     ))
+
+(defun web-mode-attribute-kill ()
+  "Kill the current html attribute."
+  (interactive)
+  (web-mode-attribute-select)
+  (when mark-active
+    (kill-region (region-beginning) (region-end))))
 
 (defun web-mode-block-close (&optional pos)
   "Close the first unclosed control block."


### PR DESCRIPTION
I have added support for web-mode-attribute-kill.  The key binding for it is: C-c C-a k, and it can be found in webmode's menu.  I've already installed my slightly modified version of web-mode, and it seems to work well.