### PR TITLE
Also test if `this-command' is not er/expand-region.

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -8672,7 +8672,8 @@ Pos should be in a tag."
     ;;(message "%S: %S %S" this-command web-mode-change-beg web-mode-change-end)
 
     (when (and web-mode-expand-previous-state
-               (not (eq this-command 'web-mode-mark-and-expand)))
+               (not (member this-command '(web-mode-mark-and-expand
+                                           er/expand-region))))
       (when (eq this-command 'keyboard-quit)
         (goto-char web-mode-expand-initial-pos))
       (deactivate-mark)


### PR DESCRIPTION
I both use `expand-region` and `web-mode`.

Without this testing, `er/expand-region' will always falls into this post-command hook, and deactivated the  mark region.

This bug annoy me several month! 