### PR TITLE
Django trans template tag does not have endtrans tag.

### DIFF
--- a/tests/demo.djhtml
+++ b/tests/demo.djhtml
@@ -63,3 +63,6 @@ related issues: #417
     Content
   {% endif %}
 </div>
+
+{% trans "" %}
+<span>Element should not be indented</span>

--- a/web-mode.el
+++ b/web-mode.el
@@ -1382,7 +1382,7 @@ Must be used in conjunction with web-mode-enable-block-face."
     "macro"
     "random" "raw"
     "safe" "sandbox" "set" "spaceless"
-    "tablerow" "trans"
+    "tablerow"
     "unless"
     "verbatim"
     "with"
@@ -1397,7 +1397,7 @@ Must be used in conjunction with web-mode-enable-block-face."
     "endmacro"
     "endrandom" "endraw"
     "endsafe" "endsandbox" "endset" "endspaceless"
-    "endtablerow" "endtrans"
+    "endtablerow"
     "endunless"
     "endverbatim"
     "endwith"
@@ -1405,7 +1405,7 @@ Must be used in conjunction with web-mode-enable-block-face."
     "csrf_token" "cycle" "debug"
     "elif" "else" "elseif" "elsif" "empty" "extends"
     "firstof" "include" "load" "lorem" "now" "regroup" "ssi"
-    "templatetag" "url" "widthratio"))
+    "trans" "templatetag" "url" "widthratio"))
 
 (defvar web-mode-django-control-blocks-regexp
   (regexp-opt web-mode-django-control-blocks t))


### PR DESCRIPTION
Hello!
I have notice that `trans` django template tag is expecting to be closed with endtrans tag.
Indentation is not working properly when using just `trans` tag.
Example:
```
{% load i18n %}
<p>
  <a href="#">{% trans "text" %}</a>
    <a href="#">link</a>
</p>
```

`endtrans` is not supported in django. I have quickly checked cousins engine docs (twig, jinja2, erlydtl, swig, liquid, selmer, clabango, nunjucksdocs) and `trans` tag is either not implemented or it is being used as in django (not block tag).

Removed `endtrans` from `defvar web-mode-django-control-blocks` and added test for `trans` tag.
Please, review.

Thank you!