### PR TITLE
tests-directory: make agnostic

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -248,7 +248,7 @@ See web-mode-part-face."
   :type 'list
   :group 'web-mode)
 
-(defcustom web-mode-tests-directory "~/Repos/web-mode/tests"
+(defcustom web-mode-tests-directory (concat default-directory "tests/")
   "Directory containing all the unit tests."
   :type 'list
   :group 'web-mode)


### PR DESCRIPTION
Redefine `web-mode-tests-directory` to be with respect to the source's
current location, rather than a user-specific location that may vary
from machine to machine.