### PR TITLE
Fix error introduced in commit 0583569

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -9652,7 +9652,7 @@ Pos should be in a tag."
   (unless pos (setq pos (point)))
   (unless limit (setq limit (point-max)))
   (cond
-   ((or (>= pos (point-max) (>= pos limit))) nil)
+   ((or (>= pos (point-max)) (>= pos limit)) nil)
    (t
     (when (get-text-property pos 'tag-beg) (setq pos (1+ pos)))
     (setq pos (next-single-property-change pos 'tag-beg))


### PR DESCRIPTION
Upon running with the current master, my Emacs (23.3.1) complains about 3
arguments given to the >= operator.

bisecting revelas commit 0583569 as the culpit.

To be completly honest, I'm not sure that this is the correct fix. However with
this fix, the all tests works again, and web-mode appears to be working as
expected again.