### PR TITLE
Enable `web-mode-element-wrap` call with argument

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -7907,12 +7907,13 @@ Pos should be in a tag."
         (deactivate-mark)
         ))))
 
-(defun web-mode-element-wrap ()
-  "Wrap current REGION with start and end tags."
+(defun web-mode-element-wrap (&optional tag-name)
+  "Wrap current REGION with start and end tags.
+Prompt user if TAG-NAME isn't provided."
   (interactive)
   (let (beg end pos tag sep)
     (save-excursion
-      (setq tag (read-from-minibuffer "Tag name? "))
+      (setq tag (or tag-name (read-from-minibuffer "Tag name? ")))
       (setq pos (point))
       (cond
        (mark-active


### PR DESCRIPTION
Currently `(web-mode-element-wrap)` prompts the user for a tag name. This MR makes it possible to provide a `TAG-NAME` argument to the function call, allowing nice keybindings such as:
```elisp
(define-key web-mode-map (kbd "C-c b")
  (lambda () (interactive) (web-mode-element-wrap "strong")))
(define-key web-mode-map (kbd "C-c i")
  (lambda () (interactive) (web-mode-element-wrap "em")))
```