### PR TITLE
`-' should be part of symbol

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -1960,6 +1960,7 @@ another auto-completion with different ac-sources (e.g. ac-php)")
   (let ((table (make-syntax-table)))
     ;; (modify-syntax-entry ?_ "_" table) ;; #563
     (modify-syntax-entry ?_ "w" table)
+    (modify-syntax-entry ?- "w" table)
     (modify-syntax-entry ?< "." table)
     (modify-syntax-entry ?> "." table)
     (modify-syntax-entry ?& "." table)


### PR DESCRIPTION
For example, consider,
- css class name like btn-default
- anglar directive like my-div
- attribute like data-on-change

Auto-completioin, code navigation need this feature