### PR TITLE
Fix js keyword highlighting

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -1555,7 +1555,7 @@ Must be used in conjunction with web-mode-enable-block-face."
 (defvar web-mode-javascript-font-lock-keywords
   (list
    '("@\\([[:alnum:]_]+\\)\\_>" 0 'web-mode-keyword-face)
-   (cons (concat "\\_<\\(" web-mode-javascript-keywords "\\)[ ]") '(1 'web-mode-keyword-face))
+   (cons (concat "\\_<\\(" web-mode-javascript-keywords "\\)\\_>") '(0 'web-mode-keyword-face))
    (cons (concat "\\_<\\(" web-mode-javascript-constants "\\)\\_>") '(0 'web-mode-constant-face))
    '("\\_<\\(new\\|instanceof\\|class\\|extends\\) \\([[:alnum:]_.]+\\)\\_>" 2 'web-mode-type-face)
    '("\\_<\\([[:alnum:]_]+\\):[ ]*function[ ]*(" 1 'web-mode-function-name-face)


### PR DESCRIPTION
Highlight js keywords which are not followed by space, such as `function(`, `if(` or `try{`.
