### PR TITLE
Riot engine support

### DIFF
--- a/tests/riot.tag
+++ b/tests/riot.tag
@@ -1,0 +1,29 @@
+<my-tag>
+  <h1>{ opts.title }</h1>
+  <script>
+   this.items = [
+     { title: 'First' }, { title: 'Second' } ]
+   
+   remove(event) {
+     
+   }
+  </script>
+
+</my-tag>
+
+<todo>
+  <div each={ items }>
+    <h3>{ title }</h3>
+    <a onclick={ parent.remove }>Remove</a>
+  </div> 
+  <script>
+
+   this.items = [
+       { title: 'First' }, { title: 'Second' } ]
+ 
+   remove(event) {
+     
+   }
+
+  </script>
+</todo>

--- a/web-mode.el
+++ b/web-mode.el
@@ -717,6 +717,7 @@ Must be used in conjunction with web-mode-enable-block-face."
     ("php"              . ())
     ("python"           . ())
     ("razor"            . ("play" "play2"))
+    ("riot"             . ())
     ("template-toolkit" . ())
     ("smarty"           . ())
     ("thymeleaf"        . ())
@@ -781,6 +782,7 @@ Must be used in conjunction with web-mode-enable-block-face."
     ("php"              . "\\.\\(p[hs]p\\|ctp\\|inc\\)\\'")
     ("python"           . "\\.pml\\'")
     ("razor"            . "\\.\\(cs\\|vb\\)html\\'")
+    ("riot"           .  "\\.tag\\'")
     ("smarty"           . "\\.tpl\\'")
     ("template-toolkit" . "\\.tt.?\\'")
     ("thymeleaf"        . "\\.thtml\\'")
@@ -990,6 +992,7 @@ Must be used in conjunction with web-mode-enable-block-face."
     ("template-toolkit" . (("[% " . " %]")
                            ("[%-" . " | %]")
                            ("[%#" . " | %]")))
+    ("riot"             . (("={ " . " }")))
     ("underscore"       . (("<% " . " %>")))
     ("web2py"           . (("{{ " . " }}")
                            ("{{=" . "}}")))
@@ -1063,6 +1066,7 @@ Must be used in conjunction with web-mode-enable-block-face."
    '("php"              . "<\\?")
    '("python"           . "<\\?")
    '("razor"            . "@.\\|^[ \t]*}")
+   '("riot"             . "{.")
    '("smarty"           . "{[[:alpha:]#$/*\"]")
    '("template-toolkit" . "\\[%.\\|%%#")
    '("underscore"       . "<%")
@@ -1689,6 +1693,14 @@ Must be used in conjunction with web-mode-enable-block-face."
    '("@\\([[:alnum:]_.]+\\)" 1 'web-mode-variable-name-face)
    ))
 
+(defvar web-mode-riot-font-lock-keywords
+  (list
+   '("\\(parent\\|opts\\|tags\\|this\\)\\.\\([[:alnum:]_.]+\\)"
+     (1 'web-mode-constant-face)
+     (2 'web-mode-variable-name-face))
+   '("\\([[:alnum:]_.]+\\)" 0 'web-mode-variable-name-face)
+   ))
+
 (defvar web-mode-closure-font-lock-keywords
   (list
    '("{/?\\([[:alpha:]]+\\)" 1 'web-mode-block-control-face)
@@ -1929,6 +1941,7 @@ Must be used in conjunction with web-mode-enable-block-face."
     ("php"              . web-mode-php-font-lock-keywords)
     ("python"           . web-mode-python-font-lock-keywords)
     ("razor"            . web-mode-razor-font-lock-keywords)
+    ("riot"             . web-mode-riot-font-lock-keywords)
     ("smarty"           . web-mode-smarty-font-lock-keywords)
     ("template-toolkit" . web-mode-template-toolkit-font-lock-keywords)
     ("underscore"       . web-mode-underscore-font-lock-keywords)
@@ -2727,6 +2740,13 @@ another auto-completion with different ac-sources (e.g. ac-php)")
             ) ; case }
            ) ;cond
           ) ;razor
+
+         ((and (string= web-mode-engine "riot")
+               (not (get-text-property reg-beg 'part-side)))
+          (setq closing-string "}"
+                delim-open "{"
+                delim-close "}")
+          ) ;riot
 
          ) ;cond
 

--- a/web-mode.el
+++ b/web-mode.el
@@ -2312,12 +2312,9 @@ another auto-completion with different ac-sources (e.g. ac-php)")
             ((member web-mode-content-type web-mode-part-content-types)
              (web-mode-scan-blocks beg end)
              (web-mode-part-scan beg end))
-            ((string= web-mode-engine "none")
-             (web-mode-scan-elements beg end)
-             (web-mode-process-parts beg end 'web-mode-part-scan))
             (t
-             (web-mode-scan-blocks beg end)
              (web-mode-scan-elements beg end)
+             (web-mode-scan-blocks beg end)
              (web-mode-process-parts beg end 'web-mode-part-scan))
             ) ;cond
            (cons beg end)
@@ -2357,7 +2354,7 @@ another auto-completion with different ac-sources (e.g. ac-php)")
           (setq sub1 (substring tagopen 0 1)
                 sub2 (substring tagopen 0 (if (>= l 2) 2 1)))
           )
-
+        ;;(message " found block #(%S) at pos=(%S), part-type=(%S)" i open (get-text-property open 'part-side))
         (cond
 
          ((string= web-mode-engine "php")
@@ -2742,7 +2739,7 @@ another auto-completion with different ac-sources (e.g. ac-php)")
           ) ;razor
 
          ((and (string= web-mode-engine "riot")
-               (not (get-text-property reg-beg 'part-side)))
+               (not (get-text-property open 'part-side)))
           (setq closing-string "}"
                 delim-open "{"
                 delim-close "}")


### PR DESCRIPTION
Hi, this patch add riot engine support.

Also commit https://github.com/osv/web-mode/commit/08eecc1dd1041c42c6ba9ef88b2bf0e447bf41bb  solve issue https://github.com/fxbois/web-mode/issues/684 - first scan elements and than block:

```lisp
(web-mode-scan-elements beg end)
(web-mode-scan-blocks beg end)
```

.. that help to check text property for engine that not support block in some parts like riot where only block supported in html.