### PR TITLE
Don't increase indent level on lines following function call

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -6863,10 +6863,11 @@ another auto-completion with different ac-sources (e.g. ac-php)")
           (setq offset (current-column)))
 
          ((and (member language '("javascript" "jsx" "ejs" "php"))
-               (or (eq prev-char ?\))
+               (or (and (eq prev-char ?\)) (string-match-p "^if\\([[:space:]]\\|(\\)" prev-line))
                    (string-match-p "^else$" prev-line))
                (not (string-match-p "^\\([{.]\\|->\\)" curr-line)))
           ;;(message "ici")
+          ;; Javascript conditional without enclosing curly braces
           (cond
            ((member language '("javascript" "jsx" "ejs"))
             (setq offset


### PR DESCRIPTION
At least partially addresses #503 .

As noted [here](http://emacs.stackexchange.com/questions/13017/web-mode-indentation-is-misaligned-on-skipping-semicolons) and [here](http://emacs.stackexchange.com/questions/20885/web-mode-javascript-auto-indenting-without-semicolons), currently, web-mode increases indent level whenever a line ends with ')'.  I think the relevant part of the code is only supposed to apply to conditional statements not contained in a curly-bracket-delimited block, and have changed the code accordingly.