### PR TITLE
elixir: fix indenting of do blocks

### DIFF
--- a/tests/indent.eex
+++ b/tests/indent.eex
@@ -1,0 +1,13 @@
+<%= if 1 + 1 == 2 do %>
+  Truth
+<% else %>
+  What?
+<% end %>
+
+<%= for i <- 1..10 do %>
+  <%= i %>
+<% end %>
+
+<%= content_tag :a, href: "https://example.com" do %>
+  Hello!
+<% end %>

--- a/web-mode.el
+++ b/web-mode.el
@@ -3751,7 +3751,7 @@ another auto-completion with different ac-sources (e.g. ac-php)")
           (setq controls (append controls (list (cons 'close "ctrl")))))
          ((web-mode-block-starts-with "else" reg-beg)
           (setq controls (append controls (list (cons 'inside "ctrl")))))
-         ((web-mode-block-starts-with "if\\|for\\|while" reg-beg)
+         ((web-mode-block-ends-with " do" reg-beg)
           (setq controls (append controls (list (cons 'open "ctrl")))))
          )
         ) ;elixir


### PR DESCRIPTION
In EEx templates (and Elixir) `if` and `for` must include a `do` before
the body (unlike ERB/Ruby). In addition, any function can accept a `do`
block as argument so we should indent anything inside them.

I just copied the logic from [here](https://github.com/fxbois/web-mode/blob/08078a39814f358a6e37898be2dd28f6ea5c6845/web-mode.el#L3474-L3475) and modified it so please tell me if I did something wrong. It seems to be working fine locally and the test I added passes with `bash run.sh`.
