### PR TITLE
Fix square bracket escape char

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -6956,7 +6956,7 @@ another auto-completion with different ac-sources (e.g. ac-php)")
          ((member language '("lsp" "cl-emb"))
           (setq offset (web-mode-lisp-indentation pos ctx)))
 
-         ((member curr-char '(?\} ?\) ?]))
+         ((member curr-char '(?\} ?\) ?\]))
           (let (ori)
             (if (get-text-property pos 'block-side)
                 (setq ori (web-mode-block-opening-paren-position pos reg-beg))


### PR DESCRIPTION
Seems to fix an error on `byte-compile-file`, `byte-code: Unmatched bracket or quote`.