### PR TITLE
Add support for Aquamacs in run.sh.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -3,6 +3,9 @@
 if [ -x /Applications/Emacs.app/Contents/MacOS/Emacs ]; 
 then
     EMACS=/Applications/Emacs.app/Contents/MacOS/Emacs
+elif [ -x /Applications/Aquamacs.app/Contents/MacOS/Aquamacs ];
+then
+    EMACS=/Applications/Aquamacs.app/Contents/MacOS/Aquamacs
 else
     EMACS=emacs
 fi


### PR DESCRIPTION
Aquamacs is a popular version of Emacs for OS X. This branch adds support for Aquamacs to run.sh.