### PR TITLE
Fix web-mode-attribute-select

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -9961,6 +9961,7 @@ Prompt user if TAG-NAME isn't provided."
     (web-mode-attribute-beginning)
     (set-mark (point))
     (web-mode-attribute-end)
+    (exchange-point-and-mark)
     (point)
     ))
 


### PR DESCRIPTION
https://github.com/magnars/expand-region.el/blob/master/expand-region-core.el#L120
expand-region's comparison algorithm assumes that an item of er/try-expand-list places the point before the mark.
This PR makes expand-region use web-mode-attribute-select.

current master
![](http://g.recordit.co/IOn9mHQe2u.gif)

this branch
![](http://g.recordit.co/sSoxOk5sEu.gif)