### PR TITLE
Improve symbol-face for emacs default theme

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -324,7 +324,7 @@ See web-mode-block-face."
   :group 'web-mode-faces)
 
 (defface web-mode-symbol-face
-  '((t :foreground "gold"))
+  '((t :foreground "goldenrod2"))
   "Face for symbols."
   :group 'web-mode-faces)
 


### PR DESCRIPTION
The contrast of `web-mode-symbol-face` was way to low when using the default emacs theme (especially when using `global-hl-line-mode`).

So change the color from `gold` = `#ffd700` to `goldenrod2` = `#eeb422`.