### PR TITLE
Improved (web-mode-link-file)

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -1172,30 +1172,19 @@ Must be used in conjunction with web-mode-enable-block-face."
     (cdr (assoc "comment" web-mode-extra-keywords))
     '("FIXME" "TODO" "BUG" "KLUDGE" "WORKAROUND" "OPTIMIZE" "HACK" "REFACTOR" "REVIEW"))))
 
-(defvar web-mode-file-extensions
-  (list
-   '("\.png$" 0 nil)
-   '("\.jpe?g$" 0 nil)
-   '("\.gif$" 0 nil)
-   '("\.svg$" 1 nil)
-   '("\.js$" 2 t)
-   '("\.css$" 3 t))
-  "List of regexps matching filetypes in `web-mode-file-link'. Second value of each list should be the index of list containing matching tags in `web-mode-file-elements', and the third one should be t if the link is supposed to be in head or nil.")
-
 (defvar web-mode-links
-  '(("<img src=\"|\" />" . "\\.\\(png\\|jpe?g\\|gif\\)$")
-    ("<object data=\"|\" type=\"image/svg+xml\"></object>" . "\\.svg$")
-    ("<script type=\"text/javascript\" src=\"|\"></script>" . "\\.js$")
-    ("<link rel=\"stylesheet\" type=\"text/css\" href=\"|\" />" . "\\.css$"))
-  "List of tags to be used by `web-mode-file-link'.")
-
-(defvar web-mode-file-elements
-  (list
-   '("<img src=\"" "\" />")
-   '("<object data=\"" "\" type=\"image/svg+xml\"></object>")
-   '("<script type=\"text/javascript\" src=\"" "\"></script>")
-   '("<link rel=\"stylesheet\" type=\"text/css\" href=\"" "\" />"))
-  "List of tags to be used by `web-mode-file-link'.")
+  '(("\\.\\(png\\|jpe?g\\|gif\\|webp\\)$" "<img src=\"%s\" alt=\"\" />" nil 4)
+    ("\\.svg$" "<object data=\"%s\" type=\"image/svg+xml\"></object>" nil 0)
+    ("\\.js$" "<script type=\"text/javascript\" src=\"%s\"></script>" t 0)
+    ("\\.css$" "<link rel=\"stylesheet\" type=\"text/css\" href=\"%s\" />" t 0)
+    ("\\.html?$" "<a href=\"%s\"></a>" nil 4))
+  "List of elements and extensions for `web-mode-file-link'. It
+consists of a string that contains the regular expression that
+matches the appropriate files, a format string with element that
+contains the link (%s should be put where the path goes,) a bool
+that tells if the element belongs in the <head> element, and
+number of characters to move back if needed (or 0 if point
+shouldn't be moved back.)")
 
 (defvar web-mode-sql-queries
   (regexp-opt
@@ -12151,33 +12140,37 @@ Prompt user if TAG-NAME isn't provided."
    (remove-hook 'change-major-mode-hook 'web-mode-on-exit t)
    ))
 
-(defun web-mode-file-link ()
-  "Insert a link to the file in html document. This function can be extended to support more filetypes by customizing `web-mode-file-extensions' and `web-mode-file-elements'."
+(defun web-mode-file-link (file)
+  "Insert a link to a file in html document. This function can be
+extended to support more filetypes by customizing
+`web-mode-links'."
   (interactive
-   (let ((type nil)
-         (file (file-relative-name (read-file-name "Link file: ")))
-         (matched nil)
-         (point-line (line-number-at-pos))
-         (point-column (current-column)))
-     (dolist (type web-mode-file-extensions)		;for every element in web-mode-type-list
-       (when (string-match (nth 0 type) file)
-         (setq matched t)
-         ;; move to head if the link requires it
-         (when (nth 2 type)
-           (goto-char (point-min))
-           (search-forward "</head>")
-           (backward-char 7)
-           (open-line 1))
-         (insert (nth 0 (nth (nth 1 type) web-mode-file-elements)) file (nth 1 (nth (nth 1 type) web-mode-file-elements)))
-         (indent-for-tab-command)
-         ;; fix indentation and return point where it was
-         (when (nth 2 type)
-           (forward-line)
-           (indent-for-tab-command)
-           (forward-line (+ point-line 1))
-           (move-to-column point-column))))
-     (when (not matched)		;return an error if filetype is unknown
-       (error "Unknown file type")))))
+   (list (file-relative-name (read-file-name "Link file: "))))
+  (let ((matched nil)
+        (point-line (line-number-at-pos))
+        (point-column (current-column)))
+    (dolist (type web-mode-links)
+      (when (string-match (car type) file)
+        (setq matched t)
+        (when (nth 2 type)
+          (goto-char (point-min))
+          (search-forward "</head>")
+          (backward-char 7)
+          (open-line 1))
+        (insert (format (cadr type) file))
+        (indent-for-tab-command)
+        (when (nth 2 type)
+          ;; return point where it was and fix indentation
+          (forward-line)
+          (indent-for-tab-command)
+          (if (> point-line (- (line-number-at-pos) 2))
+              (forward-line (+ (- point-line (line-number-at-pos)) 1))
+            (forward-line (- point-line (line-number-at-pos))))
+          (move-to-column point-column))
+        ;; move point back if needed
+        (backward-char (nth 3 type))))
+    (when (not matched)
+      (user-error "Unknown file type"))))
 
 (defun web-mode-reload ()
   "Reload web-mode."


### PR DESCRIPTION
I improved `(web-mode-link-file)` a bit. It should move the point where it should go after inserting a link, cleaned up the code so the function can be called non-interactively. I also made the code easier to read and improved the list that contains links. Now linking to images puts the point inside of the `alt` attribute, and linking to a html document puts the point inside of the `<a>` tag. I also refilled the docstrings so they aren't on a single long line.