### PR TITLE
fix: don't highlight "(" in "(function"

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -1652,7 +1652,7 @@ shouldn't be moved back.)")
 (defvar web-mode-javascript-font-lock-keywords
   (list
    '("@\\([[:alnum:]_]+\\)\\_>" 0 'web-mode-keyword-face)
-   (cons (concat "\\([ \t}{(]\\|^\\)\\(" web-mode-javascript-keywords "\\)\\_>") '(0 'web-mode-keyword-face))
+   (cons (concat "\\([ \t}{(]\\|^\\)\\(" web-mode-javascript-keywords "\\)\\_>") '(2 'web-mode-keyword-face))
    (cons (concat "\\_<\\(" web-mode-javascript-constants "\\)\\_>") '(0 'web-mode-constant-face))
    '("\\_<\\(new\\|instanceof\\|class\\|extends\\) \\([[:alnum:]_.]+\\)\\_>" 2 'web-mode-type-face)
    '("\\_<\\([[:alnum:]_]+\\):[ ]*function[ ]*(" 1 'web-mode-function-name-face)


### PR DESCRIPTION
This text:

    (function

Is selected by the regex like this:

    |(|function|
    | |        |
    |1|<- 2  ->|
    |          |
    |<-  0   ->|

    highlight = selection 0

That would highlight the "(" as well. This happens rather often with
anonymous functions, "a.each(function(e) { ... })". Instead, only
highlight selection 2, the keyword itself.

---

Before:
![before](https://cloud.githubusercontent.com/assets/3344958/20816893/909e9b5c-b7d9-11e6-999c-9370cbc08868.png)

After:
![after](https://cloud.githubusercontent.com/assets/3344958/20816896/95bf6454-b7d9-11e6-97ed-c2bd6f5cefb8.png)

