### PR TITLE
web-mode-colorize: re-enable css rgba() colorization

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -5954,7 +5954,7 @@ another auto-completion with different ac-sources (e.g. ac-php)")
       (setq plist (list :background str
                         :foreground (web-mode-colorize-foreground str)))
       (put-text-property beg end 'face plist))
-     ((string= (substring str 0 4) "rgb(")
+     ((or (string= (substring str 0 4) "rgb(") (string= (substring str 0 5) "rgba("))
       (setq str (format "#%02X%02X%02X"
                         (string-to-number (match-string-no-properties 1))
                         (string-to-number (match-string-no-properties 2))


### PR DESCRIPTION
This is already selected out of the in the regex (/rgba?/), but it
falls to the default case in `web-mode-colorize` and doesn't get
colored. Instead, put it in the same case as rgb().

As was true in the original commit enabling this (`a04b31c`), the alpha
value is ignored.

---

Before:

![before](https://cloud.githubusercontent.com/assets/3344958/20993011/97903f66-bc9c-11e6-957d-165b427a0043.png)

After:

![after](https://cloud.githubusercontent.com/assets/3344958/20993033/bb6a485a-bc9c-11e6-8b17-fe948446d309.png)
