### PR TITLE
web-mode-part-scan: faster JavaScript string parsing

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -4388,11 +4388,8 @@ another auto-completion with different ac-sources (e.g. ac-php)")
             (cond
              ((get-text-property (1- (point)) 'block-side)
               (setq continue t))
-             ((looking-back "\\\\+'" reg-beg t)
-              (setq continue (= (mod (- (point) (match-beginning 0)) 2) 0))
-              )
              (t
-              (setq continue nil))
+              (setq continue (web-mode-string-continue-p reg-beg)))
              )
             ) ;while
           (setq token-type 'string))
@@ -4402,10 +4399,8 @@ another auto-completion with different ac-sources (e.g. ac-php)")
             (cond
              ((get-text-property (1- (point)) 'block-side)
               (setq continue t))
-             ((looking-back "\\\\+`" reg-beg t)
-              (setq continue (= (mod (- (point) (match-beginning 0)) 2) 0)))
              (t
-              (setq continue nil))
+              (setq continue (web-mode-string-continue-p reg-beg)))
              )
             ) ;while
           (setq token-type 'string))
@@ -4415,10 +4410,8 @@ another auto-completion with different ac-sources (e.g. ac-php)")
             (cond
              ((get-text-property (1- (point)) 'block-side)
               (setq continue t))
-             ((looking-back "\\\\+\"" reg-beg t)
-              (setq continue (= (mod (- (point) (match-beginning 0)) 2) 0)))
              (t
-              (setq continue nil))
+              (setq continue (web-mode-string-continue-p reg-beg)))
              ) ;cond
             ) ;while
           (cond
@@ -4530,6 +4523,13 @@ another auto-completion with different ac-sources (e.g. ac-php)")
         ) ;while
 
       )))
+
+(defun web-mode-string-continue-p (reg-beg)
+  "Is `point' preceeded by an odd number of backslashes?"
+  (let* ((p (1- (point))))
+    (while (and (< reg-beg p) (eq ?\\ (char-before p)))
+      (setq p (1- p)))
+    (= (mod (- (point) p) 2) 0)))
 
 (defun web-mode-jsx-skip (reg-end)
   (let ((continue t) (pos nil) (i 0) tag)


### PR DESCRIPTION
Big JavaScript files can take a long time to open and edit:

    for i in $(seq 10000); do echo '"xxxxxxxxx"' >> test.js; done

    (setq start (float-time))
    (find-file "test.js")
    (setq end (float-time))
    (- end start)
    => 7.90

Profiling shows most time is spent in `looking-back` within
`web-mode-part-scan`. This is run once per string:

    'foo bar \\\' ack'
                ^
                |
     (looking-back "\\\\+'" reg-beg)

The documentation for `looking-back` stresses is slowness:

    As a general recommendation, try to avoid using `looking-back'
    wherever possible, since it is slow.

This commit circumvents `looking-back` by hand-coding its regex in
elisp. We're only looking for `\+`, so it's not unreasable to search for
it with a loop.

Results:

    (setq start (float-time))
    (find-file "test.js")
    (setq end (float-time))
    (- end start)
    => 0.28