### PR TITLE
web-mode-colorize: don't highlight [#fea]ture

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -5919,10 +5919,24 @@ another auto-completion with different ac-sources (e.g. ac-php)")
         ) ;when
       (goto-char sel-beg)
       (while (and web-mode-enable-css-colorization
-                  (re-search-forward "#[0-9a-fA-F]\\{6\\}\\|#[0-9a-fA-F]\\{3\\}\\|rgba?([ ]*\\([[:digit:]]\\{1,3\\}\\)[ ]*,[ ]*\\([[:digit:]]\\{1,3\\}\\)[ ]*,[ ]*\\([[:digit:]]\\{1,3\\}\\)\\(.*?\\))" end t)
+                  (re-search-forward
+                   (concat
+                    "\\("
+                    "#[0-9a-fA-F]\\{6\\}"
+                    "\\|"
+                    "#[0-9a-fA-F]\\{3\\}"
+                    "\\|"
+                    "rgba?([ ]*\\([[:digit:]]\\{1,3\\}\\)[ ]*,[ ]*\\([[:digit:]]\\{1,3\\}\\)[ ]*,[ ]*\\([[:digit:]]\\{1,3\\}\\)\\(.*?\\))"
+                    "\\)"
+                    "\\([^[:alnum:]]\\|$\\)"
+                    )
+                   end t)
                   ;;(progn (message "%S %S" end (point)) t)
                   (<= (point) end))
-        (web-mode-colorize (match-beginning 0) (match-end 0))
+        (web-mode-colorize (match-beginning 1) (match-end 1)
+                           (match-string-no-properties 2)
+                           (match-string-no-properties 3)
+                           (match-string-no-properties 4))
         ) ;while
       ) ;let
     ))
@@ -5951,7 +5965,7 @@ another auto-completion with different ac-sources (e.g. ac-php)")
     (if (> 128.0 (floor (+ (* .3 r) (* .59 g) (* .11 b)) 256))
 	"white" "black")))
 
-(defun web-mode-colorize (beg end)
+(defun web-mode-colorize (beg end &optional r g b)
   (let (str plist len)
     (setq str (buffer-substring-no-properties beg end))
     (setq len (length str))
@@ -5960,11 +5974,11 @@ another auto-completion with different ac-sources (e.g. ac-php)")
       (setq plist (list :background str
                         :foreground (web-mode-colorize-foreground str)))
       (put-text-property beg end 'face plist))
-     ((or (string= (substring str 0 4) "rgb(") (string= (substring str 0 5) "rgba("))
+     ((and r g b)
       (setq str (format "#%02X%02X%02X"
-                        (string-to-number (match-string-no-properties 1))
-                        (string-to-number (match-string-no-properties 2))
-                        (string-to-number (match-string-no-properties 3))))
+                        (string-to-number r)
+                        (string-to-number g)
+                        (string-to-number b)))
       (setq plist (list :background str
                         :foreground (web-mode-colorize-foreground str)))
       (put-text-property beg end 'face plist))


### PR DESCRIPTION
Before, this CSS:

    #features {
    }

...would have `#fea` highlighted a yellowish color, since `#fea` is
a hex color. Personally I've encountered `#feedba`ck, and there's
hundreds of other English words that start with `[a-f]{3}`.

This commit, extends the regex to end with `[^[:alnum:]]`. This won't
damage existing highlighting (`#fffx` is invalid), and will throw out
English words with 4 or more characters.

This does not 100% fix CSS colorization; we'll continue to erroneously
colorize this CSS:

    #fea {
    }

...but fixing that would require a much bigger change.

Fixes #818.

---

Before:

![before](https://cloud.githubusercontent.com/assets/3344958/21695881/7172c370-d340-11e6-905d-8176a8a120b7.png)

After:

![after](https://cloud.githubusercontent.com/assets/3344958/21695884/75c88662-d340-11e6-9472-c404921c3528.png)
