### PR TITLE
Support Twig's `for...else...endfor` construct

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -3587,7 +3587,24 @@ another auto-completion with different ac-sources (e.g. ac-php)")
         (when (eq (char-after (1+ reg-beg)) ?\%)
           (cond
            ((and (string= web-mode-minor-engine "jinja") ;#504
-                 (web-mode-block-starts-with "else\\_>" reg-beg))
+                 (web-mode-block-starts-with "else\\>" reg-beg))
+            (let ((continue t)
+                  (pos reg-beg)
+                  (ctrl nil))
+              (while continue
+                (cond
+                 ((null (setq pos (web-mode-block-control-previous-position 'open pos)))
+                  (setq continue nil))
+                 ((member (setq ctrl (cdr (car (get-text-property pos 'block-controls)))) '("if" "for"))
+                  (setq continue nil)
+                  )
+                 ) ;cond
+                )
+              (setq controls (append controls (list (cons 'inside (or ctrl "if")))))
+              )
+            )
+           ((and (string= web-mode-minor-engine "twig")
+                 (web-mode-block-starts-with "\\(else\\|elseif\\)" reg-beg))
             (let ((continue t)
                   (pos reg-beg)
                   (ctrl nil))

--- a/web-mode.el
+++ b/web-mode.el
@@ -847,9 +847,10 @@ Must be used in conjunction with web-mode-enable-block-face."
     ("smarty"           . "\\.tpl\\'")
     ("template-toolkit" . "\\.tt.?\\'")
     ("thymeleaf"        . "\\.thtml\\'")
+    ("twig"             . "\\.twig")
     ("velocity"         . "\\.v\\(sl\\|tl\\|m\\)\\'")
 
-    ("django"           . "[st]wig")
+    ("django"           . "swig")
     ("razor"            . "scala")
 
     )


### PR DESCRIPTION
Twig supports a `for...else...endfor` that allows inserting different content when the loop doesn't iterate.  (It works exactly like django's `for...empty...endfor` construct, but with `else` as the keyword).

This patch set adds a special case for handling `else` while using the "twig" minor engine.  In addition, it activates the twig minor engine by default for buffers whose name contains ".twig".