### PR TITLE
Electric block closing

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -235,6 +235,11 @@ See web-mode-block-face."
   :type '(choice (const :tag "Auto-quotes with double quote" 1)
                  (const :tag "Auto-quotes with single quote" 2)))
 
+(defcustom web-mode-enable-electric-block-closing nil
+  "Enable electric indentation on }, ] and )."
+  :group 'web-mode
+  :type 'boolean)
+
 (defcustom web-mode-extra-expanders '()
   "A list of additional expanders."
   :type 'list
@@ -9944,6 +9949,13 @@ Prompt user if TAG-NAME isn't provided."
     (when (and web-mode-enable-current-column-highlight
                (not (web-mode-buffer-narrowed-p)))
       (web-mode-column-show))
+
+    (when (and web-mode-enable-electric-block-closing
+               (eq this-command 'self-insert-command)
+               (string-match
+                "^[ \t]*[]})]"
+                (thing-at-point 'line t)))
+      (indent-according-to-mode))
 
     ;;(message "post-command (%S) (%S)" web-mode-change-end web-mode-change-end)
 


### PR DESCRIPTION
I wanted a feature similar to electric-brace in cc-mode, as I'd gotten used to that and it affected the way I code. Here I emulated the effect on }, ] and ).

I left it disabled by default, and as such it was easier to leave as a post-command hook and enable the effect on all three characters at once. Cc-mode, however, electric-brace is a key binding on each individual character, not a post-command hook. The difference is visible when show-paren-mode is enabled (as it is by default), since it runs first - the cursor will blink back to the matching brace-paren, then indent the closing brace.

This feature is enabled with `(setq web-mode-enable-electric-block-closing t)` in your web-mode-hook.

I see the last commit prior to this - 8139cfa - might have attempted a similar feature; however I'm not getting the same effect.