### PR TITLE
Fix issue #564

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -9940,7 +9940,9 @@ Prompt user if TAG-NAME isn't provided."
 
     (when (and web-mode-enable-auto-indentation
                (member this-command '(self-insert-command))
-               (member (get-text-property (point) 'part-side) '(javascript))
+               (or
+                 (member (get-text-property (point) 'part-side) '(javascript))
+                 (member (get-text-property (point) 'part-side) '(jsx)))
                (looking-back "^[ \t]+\\(}\\|\]\\)"))
       (indent-according-to-mode)
       ;;(message "%S" (point))

--- a/web-mode.el
+++ b/web-mode.el
@@ -9940,9 +9940,7 @@ Prompt user if TAG-NAME isn't provided."
 
     (when (and web-mode-enable-auto-indentation
                (member this-command '(self-insert-command))
-               (or
-                 (member (get-text-property (point) 'part-side) '(javascript))
-                 (member (get-text-property (point) 'part-side) '(jsx)))
+               (member (get-text-property (point) 'part-side) '(javascript jsx))
                (looking-back "^[ \t]+\\(}\\|\]\\)"))
       (indent-according-to-mode)
       ;;(message "%S" (point))


### PR DESCRIPTION
@fxbois I pulled your [revision](https://github.com/fxbois/web-mode/commit/8139cfa03dc80d78c258147095eb4204b2f75be8) to fix issue 564, when it was still occurring for me after your change.

This code: `(get-text-property (point) 'part-side)` evaluates to `jsx` for me, not `javascript`.

The patch here fixes it for my environment; no idea if there's a cleaner way to do it. It's been ~20 years since I've written any e-lisp.