### PR TITLE
Add requirement on Emacs 23+

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -6,12 +6,15 @@
 ;; Version: 14.1.1
 ;; Author: François-Xavier Bois <fxbois AT Google Mail Service>
 ;; Maintainer: François-Xavier Bois
+;; Package-Requires: ((emacs "23.1"))
 ;; URL: http://web-mode.org
 ;; Repository: http://github.com/fxbois/web-mode
 ;; Created: July 2011
 ;; Keywords: languages
 ;; License: GNU General Public License >= 2
 ;; Distribution: This file is not part of Emacs
+
+;;; Commentary:
 
 ;;==============================================================================
 ;; WEB-MODE is sponsored by ** Kernix ** Best DigitalFactory & DataLab in Paris


### PR DESCRIPTION
The `:safe` keyword was added to Emacs in version 23 (http://stackoverflow.com/a/5386504), so as of https://github.com/fxbois/web-mode/commit/007c8c8c4d5d33bf707b8300cf223a605e629cf0 web-mode doesn't work on 22 or lower.