### PR TITLE
Attribute kill: delete a space that stay before the last ">"

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -10552,6 +10552,10 @@ Prompt user if TAG-NAME isn't provided."
         ) ;let
       ) ;when
     ) ;while
+  ;; Delete a potential space before the closing ">".
+  (if (and (looking-at ">")
+           (looking-back " "))
+        (delete-char -1))
   )
 
 (defun web-mode-block-close (&optional pos)


### PR DESCRIPTION
A little fix for what's annoyed me lately :)

When I delete an attribute (C-c C-a k, attribute-kill), if it is the last one there may be a remaining space before the closing ">":

```
      <ul class="pagination pagination-sm no-margin" style="block-inline">
```
killing:

```
      <ul class="pagination pagination-sm no-margin" >
```
this commit gives:

```
      <ul class="pagination pagination-sm no-margin">
```