### PR TITLE
riot engine: added virtual script block

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -1166,7 +1166,7 @@ Must be used in conjunction with web-mode-enable-block-face."
    '("php"              . "<\\?")
    '("python"           . "<\\?")
    '("razor"            . "@.\\|^[ \t]*}")
-   '("riot"             . "{.")
+   '("riot"             . "{.\\|/// begin script")
    '("smarty"           . "{[[:alpha:]#$/*\"]")
    '("spip"             . "\\[(#REM)\\|(\\|#[A-Z0-9_]\\|{\\|<:")
    '("template-toolkit" . "\\[%.\\|%%#")
@@ -2983,7 +2983,7 @@ another auto-completion with different ac-sources (e.g. ac-php)")
 
          ((and (string= web-mode-engine "riot")
                (not (get-text-property open 'part-side)))
-          (setq closing-string "}"
+          (setq closing-string (if (string= tagopen "{") "}" "/// end script")
                 delim-open "{"
                 delim-close "}")
           ) ;riot


### PR DESCRIPTION
End of inside area is for javascript on a tag mounted by riot.
It is supported by virtual script area(between "/// begin script" to "/// end script").

e.g.)
```
<riot-tag>
  <ul>
    <li each={ items }>{ name }</li>
  </ul>

  /// begin script

  this.items = [ {name: "aaa"}, {name: "bbb"}, {name: "ccc"} ];

  /// end script
</riot-tag>
```