### PR TITLE
Specify self-closing (void) tag during element insert

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -6,7 +6,7 @@
 ;; Version: 15.0.23
 ;; Author: François-Xavier Bois <fxbois AT Google Mail Service>
 ;; Maintainer: François-Xavier Bois
-;; Package-Requires: ((emacs "23.1"))
+;; Package-Requires: ((emacs "24.4"))
 ;; URL: http://web-mode.org
 ;; Repository: http://github.com/fxbois/web-mode
 ;; Created: July 2011
@@ -9228,7 +9228,7 @@ Prompt user if TAG-NAME isn't provided."
                 (> (length tag-name) 0)))
       (message "element-insert ** failure **"))
      ((web-mode-element-is-void tag-name)
-      (insert (concat "<" tag-name "/>"))
+      (insert (concat "<" (string-remove-suffix "/" tag-name) "/>"))
       )
      (mark-active
       (let ((beg (region-beginning)) (end (region-end)))
@@ -9370,6 +9370,8 @@ Prompt user if TAG-NAME isn't provided."
     t)
    ((and tag (member tag '("div" "li" "a" "p" "h1" "h2" "h3" "ul" "span" "article" "section" "td" "tr")))
     nil)
+   ((and tag (string-suffix-p "/" tag))
+    t)
    ((and tag (string= web-mode-content-type "jsx"))
     (member (downcase tag) '("img" "br" "hr")))
    (tag

--- a/web-mode.el
+++ b/web-mode.el
@@ -6,7 +6,7 @@
 ;; Version: 15.0.23
 ;; Author: François-Xavier Bois <fxbois AT Google Mail Service>
 ;; Maintainer: François-Xavier Bois
-;; Package-Requires: ((emacs "24.4"))
+;; Package-Requires: ((emacs "23.1"))
 ;; URL: http://web-mode.org
 ;; Repository: http://github.com/fxbois/web-mode
 ;; Created: July 2011
@@ -2389,6 +2389,16 @@ another auto-completion with different ac-sources (e.g. ac-php)")
   (unless (fboundp 'setq-local)
     (defmacro setq-local (var val)
     `(set (make-local-variable ',var) ,val)))
+
+  ;; compatability with emacs < 24.4
+  (defun web-mode-string-suffix-p (suffix string)
+    "Return t if STRING ends with SUFFIX."
+      (and (string-match (rx-to-string `(: ,suffix eos) t)
+                         string)
+           t))
+
+  (unless (fboundp 'string-suffix-p)
+    (fset 'string-suffix-p (symbol-function 'web-mode-string-suffix-p)))
 
   ) ;eval-and-compile
 
@@ -9228,7 +9238,7 @@ Prompt user if TAG-NAME isn't provided."
                 (> (length tag-name) 0)))
       (message "element-insert ** failure **"))
      ((web-mode-element-is-void tag-name)
-      (insert (concat "<" (string-remove-suffix "/" tag-name) "/>"))
+      (insert (concat "<" (replace-regexp-in-string "/" "" tag-name) "/>"))
       )
      (mark-active
       (let ((beg (region-beginning)) (end (region-end)))


### PR DESCRIPTION
I use web-mode a lot for React projects - this change allows the user to append `/` to an element name when calling `web-mode-element-insert` to allow any tag to be input as a self-closing/void tag.

The only potential downside of this change is that the `(string-remove-suffix)` method was introduced in Emacs 24.4, hence bumping the required Emacs version.