### PR TITLE
fix(web-mode) avoid greedy uncommenting

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -9970,7 +9970,7 @@ Prompt user if TAG-NAME isn't provided."
           ;;(message "%S" comment)
           )
          ((string= sub2 "//")
-          (setq comment (replace-regexp-in-string "\\(//\\)" "" comment)))
+          (setq comment (replace-regexp-in-string "^ *//" "" comment)))
          ) ;cond
         (delete-region beg end)
         (web-mode-insert-and-indent comment)


### PR DESCRIPTION
Fixes https://github.com/fxbois/web-mode/issues/980

FWIW I am a novice elisper, so any suggestions would be helpful :pray: I found some help in solving this problem on this thread: https://emacs.stackexchange.com/a/39368/2676


Output of `M-x web-mode-debug`:

>--- WEB-MODE DEBUG BEG ---
>versions: emacs(25.3) web-mode("15.0.19")
>vars: engine(nil) minor(nil) content-type("") file("/home/me/projects/elisps/web-mode/web-mode.el")
>system: window(x) config("x86_64-pc-linux-gnu")
>colors: fg("white") bg("#2E2E2E")
>minor modes: (global-visual-line-mode size-indication-mode global-eldoc-mode image-diredx-async-mode evil-local-mode evil-mode shell-dirtrack-mode undo-tree-mode global-undo-tree-mode erc-readonly-mode erc-move-to-prompt-mode erc-noncommands-mode erc-irccontrols-mode erc-stamp-mode erc-fill-mode erc-button-mode erc-hl-nicks-mode erc-netsplit-mode erc-match-mode erc-track-mode erc-pcomplete-mode erc-networks-mode erc-ring-mode erc-autojoin-mode erc-menu-mode erc-list-mode flycheck-mode global-flycheck-mode dumb-jump-mode yas-minor-mode yas-global-mode desktop-save-mode async-bytecomp-package-mode helm-mode pyvenv-mode diff-auto-refine-mode pdf-occur-global-minor-mode imagex-sticky-mode imagex-global-sticky-mode git-gutter-mode global-git-gutter-mode auto-complete-mode global-auto-complete-mode show-paren-mode subword-mode global-auto-revert-mode)
>vars:
>web-mode-enable-current-column-highlight=nil
>web-mode-enable-current-element-highlight=t
>indent-tabs-mode=nil
>--- WEB-MODE DEBUG END ---
