### PR TITLE
fix indentation of anonymous functions in eex templates

### DIFF
--- a/tests/test.eex
+++ b/tests/test.eex
@@ -11,3 +11,7 @@
 <%= content_tag :a, href: "https://example.com" do %>
   Hello!
 <% end %>
+
+<%= form_for @changeset, @action, fn _form -> %>
+  Hello again!
+<%= end %>

--- a/web-mode.el
+++ b/web-mode.el
@@ -4284,6 +4284,8 @@ another auto-completion with different ac-sources (e.g. ac-php)")
           (setq controls (append controls (list (cons 'inside "ctrl")))))
          ((web-mode-block-ends-with " do" reg-beg)
           (setq controls (append controls (list (cons 'open "ctrl")))))
+         ((web-mode-block-ends-with " ->" reg-beg)
+          (setq controls (append controls (list (cons 'open "ctrl")))))
          )
         ) ;elixir
 


### PR DESCRIPTION
This PR fixes the indentation of eex blocks which have an anonymous function as their body.
Currently the body of an eex block is not correctly indented when there is no `do`.

The correctly indented code in this example

```html
<%= form_for @changeset, @action, fn _form -> %>
  Hello again!
<%= end %>
```

previously resulted in the following

```html
<%= form_for @changeset, @action, fn _form -> %>
Hello again!
<%= end %>
```