### PR TITLE
Always enable auto-indentation etc. by default

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -119,27 +119,27 @@
   :type 'boolean
   :group 'web-mode)
 
-(defcustom web-mode-enable-auto-indentation (display-graphic-p)
+(defcustom web-mode-enable-auto-indentation t
   "Auto-indentation."
   :type 'boolean
   :group 'web-mode)
 
-(defcustom web-mode-enable-auto-closing (display-graphic-p)
+(defcustom web-mode-enable-auto-closing t
   "Auto-closing."
   :type 'boolean
   :group 'web-mode)
 
-(defcustom web-mode-enable-auto-pairing (display-graphic-p)
+(defcustom web-mode-enable-auto-pairing t
   "Auto-pairing."
   :type 'boolean
   :group 'web-mode)
 
-(defcustom web-mode-enable-auto-opening (display-graphic-p)
+(defcustom web-mode-enable-auto-opening t
   "Html element auto-opening."
   :type 'boolean
   :group 'web-mode)
 
-(defcustom web-mode-enable-auto-quoting (display-graphic-p)
+(defcustom web-mode-enable-auto-quoting t
   "Add double quotes after the character = in a tag."
   :type 'boolean
   :group 'web-mode)


### PR DESCRIPTION
Thanks for such an excellent mode!  I've been using it for many years - it's just recently that I've located an improvement that I think could be made.  When I open it up over SSH, auto-closing does not occur.  The source sets the default value of `web-mode-enable-auto-closing` to `(display-graphic-p)` but there's no reason to predicate that particular feature on being in a graphical window that can display several frames and fonts at once.  Changed `web-mode-enable-auto-closing` to default to `t` along with some other nearby features that looked like they had the same problem.  Thanks again:)