### PR TITLE
[[feature]] Adding Support for Artanis, Web Application Framework, Template Files

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -2207,8 +2207,8 @@ shouldn't be moved back.)")
   (list
    (cons (concat "\\_<\\(" web-mode-artanis-keywords  "\\)\\_>") '(0 'web-mode-keyword-face))
    (cons (concat "\\_<\\(" web-mode-artanis-constants "\\)\\_>") '(0 'web-mode-constant-face))
-   '("(define[*]? (\\([[:alnum:]-:]+\\)"     1 'web-mode-function-name-face)
-   '("\\(#:[[:alnum:]-:_!#$%^&*=+/?<>.]+\\)" 1 'web-mode-builtin-face)
+   '("(define[*]? (\\([[:alnum:]-:_!#$%^&*=+/?<>.]+\\)" 1 'web-mode-function-name-face)
+   '("\\(#:[[:alnum:]-:_!#$%^&*=+/?<>.]+\\)"            1 'web-mode-builtin-face)
    ))
 
 (defvar web-mode-php-font-lock-keywords

--- a/web-mode.el
+++ b/web-mode.el
@@ -1171,7 +1171,16 @@ Must be used in conjunction with web-mode-enable-block-face."
     ))
 
 (defvar web-mode-engines-snippets
-  '(("ejs" . (("for"     . "<% for (|) { %>\n\n<% } %>")
+  '(("artanis" . (("if"       . "<% (if (|) %>\n\n<% ) %>")
+                  ("when"     . "<% (when (|) %>\n\n<% ) %>")
+                  ("unless"   . "<% (unless (|) %>\n\n<% ) %>")
+                  ("cond"     . "<% (cond %>\n<%  [(|) %>\n\n<%  ] %>\n<%  [else %>\n\n<%  ] %>\n<% ) %>")
+                  ("let"      . "<% (let ([|]) %>\n\n<% ) %>")
+                  ("let*"     . "<% (let* ([|]) %>\n\n<% ) %>")
+                  ("do"       . "<% (do ([|]) %>\n<%     [()] %>\n\n<% ) %>")
+                  ("for-each" . "<% (for-each %>\n|\n\n<% ) %>")
+                  ("case"     . "<% (case | %>\n<%   [() %>\n\n<%   ] %>\n<%   [() %>\n\n<%   ] %>\n<% ) %>")))
+    ("ejs" . (("for"     . "<% for (|) { %>\n\n<% } %>")
               ("if"      . "<% if (|) { %>\n\n<% } %>")))
     ("erb" . (("each"    . "<% |.each do  %>\n\n<% end %>")
               ("if"      . "<% if | %>\n\n<% end %>")

--- a/web-mode.el
+++ b/web-mode.el
@@ -1373,7 +1373,7 @@ shouldn't be moved back.)")
       "match-lambda" "match-lambda*" "match-let" "match-let*"
       "match-letrec" "let" "let*" "letrec" "letrec*" "and-let*"
       "let-syntax" "letrec-syntax" "syntax-rules" "syntax-case"
-      "display" "define" "define-syntax" "define-macro"
+      "define" "define-syntax" "define-macro"
       "define-condition-type" "define-immutable-record-type"
       "define-record-type" "define-values" "parameterize" "for-each"
       "require-extension" "set!" "test-approximate" "test-assert"

--- a/web-mode.el
+++ b/web-mode.el
@@ -4090,34 +4090,6 @@ another auto-completion with different ac-sources (e.g. ac-php)")
          )
         ) ;erb
 
-       ((string= web-mode-engine "artanis")
-        (cond
-         ((web-mode-block-starts-with "\\()\\|]\\)" reg-beg)
-          (setq controls (append controls (list (cons 'close "ctrl")))))
-         ((and (web-mode-block-starts-with "\\((\\|\\[\\)" reg-beg)
-               ;; Regex if you want to target tag blocks that only
-               ;; have an open parenthesis and whitespace/newlines
-               ;; "\\((\\|\\[\\)\\([[:blank:]]\\|\n\\|^%\\)*[^[:blank:]\n%]\\(.\\|\n\\|^%\\)*?%>"
-               (condition-case ex
-                   (let* ((pos  reg-beg)
-                          (temp (save-excursion
-                                  (web-mode-block-beginning)
-                                  (web-mode-block-skip-blank-forward)
-                                  (buffer-substring
-                                    (point)
-                                    (condition-case ex2
-                                        (progn (search-forward "%>") (point))
-                                      (point-max))))))
-                     (with-temp-buffer
-                       (insert temp)
-                       (move-beginning-of-line 1)
-                       (forward-sexp)
-                       nil))
-                 ('error t)))
-          (setq controls (append controls (list (cons 'open "ctrl")))))
-         )
-        ) ;artanis
-
        ((string= web-mode-engine "django")
         (cond
          ((and (string= web-mode-minor-engine "jinja") ;#504

--- a/web-mode.el
+++ b/web-mode.el
@@ -4088,6 +4088,34 @@ another auto-completion with different ac-sources (e.g. ac-php)")
          )
         ) ;erb
 
+       ((string= web-mode-engine "artanis")
+        (cond
+         ((web-mode-block-starts-with "\\()\\|]\\)" reg-beg)
+          (setq controls (append controls (list (cons 'close "ctrl")))))
+         ((and (web-mode-block-starts-with "\\((\\|\\[\\)" reg-beg)
+               ;; Regex if you want to target tag blocks that only
+               ;; have an open parenthesis and whitespace/newlines
+               ;; "\\((\\|\\[\\)\\([[:blank:]]\\|\n\\|^%\\)*[^[:blank:]\n%]\\(.\\|\n\\|^%\\)*?%>"
+               (condition-case ex
+                   (let* ((pos  reg-beg)
+                          (temp (save-excursion
+                                  (web-mode-block-beginning)
+                                  (web-mode-block-skip-blank-forward)
+                                  (buffer-substring
+                                    (point)
+                                    (condition-case ex2
+                                        (progn (search-forward "%>") (point))
+                                      (point-max))))))
+                     (with-temp-buffer
+                       (insert temp)
+                       (move-beginning-of-line 1)
+                       (forward-sexp)
+                       nil))
+                 ('error t)))
+          (setq controls (append controls (list (cons 'open "ctrl")))))
+         )
+        ) ;artanis
+
        ((string= web-mode-engine "django")
         (cond
          ((and (string= web-mode-minor-engine "jinja") ;#504

--- a/web-mode.el
+++ b/web-mode.el
@@ -9990,6 +9990,10 @@ Prompt user if TAG-NAME isn't provided."
       (web-mode-comment-erb-block pos)
       )
 
+     ((and block-side (string= web-mode-engine "artanis"))
+      (web-mode-comment-artanis-block pos)
+      )
+
      ((and single-line-block block-side
            (intern-soft (concat "web-mode-comment-" web-mode-engine "-block")))
         (funcall (intern (concat "web-mode-comment-" web-mode-engine "-block")) pos)
@@ -10032,6 +10036,8 @@ Prompt user if TAG-NAME isn't provided."
           (setq content (concat "{# " sel " #}")))
          ((and (= web-mode-comment-style 2) (member web-mode-engine '("ejs" "erb")))
           (setq content (concat "<%# " sel " %>")))
+         ((and (= web-mode-comment-style 2) (string= web-mode-engine "artanis"))
+          (setq content (concat "<%; " sel " %>")))
          ((and (= web-mode-comment-style 2) (string= web-mode-engine "aspx"))
           (setq content (concat "<%-- " sel " --%>")))
          ((and (= web-mode-comment-style 2) (string= web-mode-engine "smarty"))
@@ -10114,6 +10120,12 @@ Prompt user if TAG-NAME isn't provided."
     (setq beg (web-mode-block-beginning-position pos)
           end (web-mode-block-end-position pos))
     (web-mode-insert-text-at-pos "#" (+ beg 2))))
+
+(defun web-mode-comment-artanis-block (pos)
+  (let (beg end)
+    (setq beg (web-mode-block-beginning-position pos)
+          end (web-mode-block-end-position pos))
+    (web-mode-insert-text-at-pos ";" (+ beg 2))))
 
 (defun web-mode-comment-django-block (pos)
   (let (beg end)
@@ -10243,6 +10255,22 @@ Prompt user if TAG-NAME isn't provided."
           end (web-mode-block-end-position pos))
     (cond
      ((string= (buffer-substring-no-properties beg (+ beg 4)) "<%#=")
+      (web-mode-remove-text-at-pos 1 (+ beg 2)))
+     ((string-match-p "<[%[:alpha:]]" (buffer-substring-no-properties (+ beg 2) (- end 2)))
+      (web-mode-remove-text-at-pos 2 (1- end))
+      (web-mode-remove-text-at-pos 3 beg))
+     (t
+      (web-mode-remove-text-at-pos 1 (+ beg 2)))
+      ) ;cond
+    )
+  )
+
+(defun web-mode-uncomment-artanis-block (pos)
+  (let (beg end)
+    (setq beg (web-mode-block-beginning-position pos)
+          end (web-mode-block-end-position pos))
+    (cond
+     ((string= (buffer-substring-no-properties beg (+ beg 4)) "<%;=")
       (web-mode-remove-text-at-pos 1 (+ beg 2)))
      ((string-match-p "<[%[:alpha:]]" (buffer-substring-no-properties (+ beg 2) (- end 2)))
       (web-mode-remove-text-at-pos 2 (1- end))

--- a/web-mode.el
+++ b/web-mode.el
@@ -810,6 +810,7 @@ Must be used in conjunction with web-mode-enable-block-face."
 (defvar web-mode-engines
   '(("angular"          . ("angularjs"))
     ("archibus"         . ())
+    ("artanis"          . ())
     ("asp"              . ())
     ("aspx"             . ())
     ("blade"            . ("laravel"))
@@ -887,6 +888,7 @@ Must be used in conjunction with web-mode-enable-block-face."
 
 (defvar web-mode-engine-file-regexps
   '(("angular"          . "\\.component.html\\'")
+    ("artanis"          . "\\.tpl\\'")
     ("asp"              . "\\.asp\\'")
     ("aspx"             . "\\.as[cp]x\\'")
     ("archibus"         . "\\.axvw\\'")
@@ -1073,6 +1075,12 @@ Must be used in conjunction with web-mode-enable-block-face."
 
 (defvar web-mode-engines-auto-pairs
   '(("angular"          . (("{{ " . " }}")))
+    ("artanis"          . (("<% "       . " %>")
+                           ("<%="       . " | %>")
+                           ("<@css"     . " | %>")
+                           ("<@icon"    . " | %>")
+                           ("<@include" . " | %>")
+                           ("<@js"      . " | %>")))
     ("asp"              . (("<% " . " %>")))
     ("aspx"             . (("<% " . " %>")
                            ("<%=" . "%>")
@@ -1195,6 +1203,7 @@ Must be used in conjunction with web-mode-enable-block-face."
 
 (defvar web-mode-engine-token-regexps
   (list
+   '("artanis"     . "\"\\|#|\\|;")
    '("asp"         . "//\\|/\\*\\|\"\\|'")
    '("ejs"         . "//\\|/\\*\\|\"\\|'")
    '("erb"         . "\"\\|'\\|#\\|<<[-]?['\"]?\\([[:alnum:]_]+\\)['\"]?")
@@ -1210,6 +1219,7 @@ Must be used in conjunction with web-mode-enable-block-face."
 (defvar web-mode-engine-open-delimiter-regexps
   (list
    '("angular"          . "{{")
+   '("artanis"          . "<%\\|<@\\(css\\|icon\\|include\\|js\\)")
    '("asp"              . "<%\\|</?[[:alpha:]]+:[[:alpha:]]+\\|</?[[:alpha:]]+Template")
    '("aspx"             . "<%.")
    '("blade"            . "{{.\\|{!!\\|@{{\\|@[[:alpha:]]")
@@ -2767,6 +2777,23 @@ another auto-completion with different ac-sources (e.g. ac-php)")
            )
           ) ;cl-emb
 
+         ((string= web-mode-engine "artanis")
+          (cond
+           ((string= tagopen "<%;")
+            (setq closing-string "%>"))
+           ((string= tagopen "<%#|")
+            (setq closing-string "|#%>"))
+           ((string= sub2 "<@")
+            (setq closing-string "%>"
+                  delim-open "<@\\(css\\|icon\\|include\\|js\\)"
+                  delim-close "%>"))
+           ((string= sub2 "<%")
+            (setq closing-string "%>"
+                  delim-open "<%[=]?"
+                  delim-close "%>"))
+           )
+          ) ;artanis
+
          ((string= web-mode-engine "elixir")
           (cond
            ((member (char-after) '(?\#))
@@ -3489,7 +3516,7 @@ another auto-completion with different ac-sources (e.g. ac-php)")
   "Set text-property 'block-token to 'delimiter-(beg|end) on block delimiters (e.g. <?php and ?>)"
   ;;(message "reg-beg(%S) reg-end(%S) delim-open(%S) delim-close(%S)" reg-beg reg-end delim-open delim-close)
   (when (member web-mode-engine
-                '("asp" "aspx" "cl-emb" "clip" "closure" "ctemplate" "django" "dust"
+                '("artanis" "asp" "aspx" "cl-emb" "clip" "closure" "ctemplate" "django" "dust"
                   "elixir" "ejs" "erb" "freemarker" "go" "hero" "jsp" "lsp" "mako" "mason" "mojolicious"
                   "smarty" "template-toolkit" "web2py" "xoops"))
     (save-excursion
@@ -3636,6 +3663,17 @@ another auto-completion with different ac-sources (e.g. ac-php)")
         (setq regexp "\"\\|'"))
        )
       ) ;cl-emb
+
+     ((string= web-mode-engine "artanis")
+      (cond
+       ((string= sub3 "<%;")
+        (setq token-type 'comment))
+       ((string= sub3 "<%#|")
+        (setq token-type 'comment))
+       (t
+        (setq regexp "\""))
+       )
+      ) ;artanis
 
      ((string= web-mode-engine "elixir")
       (cond
@@ -7749,7 +7787,7 @@ another auto-completion with different ac-sources (e.g. ac-php)")
                                                  curr-indentation
                                                  reg-beg)))
 
-         ((member language '("lsp" "cl-emb"))
+         ((member language '("lsp" "cl-emb" "artanis"))
           (when debug (message "I240(%S) lsp" pos))
           (setq offset (web-mode-lisp-indentation pos ctx)))
 
@@ -11267,6 +11305,7 @@ Prompt user if TAG-NAME isn't provided."
    ((string= web-mode-engine "lsp")               "<% ) %>")
    ((string= web-mode-engine "erb")               "<% } %>")
    ((string= web-mode-engine "erb")               "<% end %>")
+   ((string= web-mode-engine "artanis")           "<% ) %>")
    ((string= web-mode-engine "hero")              "<% } %>")
    ((string= web-mode-engine "go")                "{{end}}")
    ((string= web-mode-engine "velocity")          "#end")

--- a/web-mode.el
+++ b/web-mode.el
@@ -1350,6 +1350,27 @@ shouldn't be moved back.)")
      "endrepeat" "loop" "endloop" "include" "call" "with"
      "endwith" "set" "genloop" "endgenloop" "insert")))
 
+(defvar web-mode-artanis-constants
+  (regexp-opt
+   '("#f" "#t")))
+
+(defvar web-mode-artanis-keywords
+  (regexp-opt
+   (append
+    (cdr (assoc "artanis" web-mode-extra-keywords))
+    '("begin" "cut" "cute" "if" "when" "unless" "cond" "case"
+      "do" "quote" "syntax" "lambda" "lambda*" "and" "and-let*"
+      "or" "else" "delay" "receive" "use-modules" "match"
+      "match-lambda" "match-lambda*" "match-let" "match-let*"
+      "match-letrec" "let" "let*" "letrec" "letrec*" "and-let*"
+      "let-syntax" "letrec-syntax" "syntax-rules" "syntax-case"
+      "display" "define" "define-syntax" "define-macro"
+      "define-condition-type" "define-immutable-record-type"
+      "define-record-type" "define-values" "parameterize" "for-each"
+      "require-extension" "set!" "test-approximate" "test-assert"
+      "test-begin" "test-end" "test-eq" "test-equal" "test-eqv"
+      "test-error" "test-group" "test-group-with-cleanup" "test-with-runner"))))
+
 (defvar web-mode-lsp-constants
   (regexp-opt
    '("nil" "t")))
@@ -2173,6 +2194,14 @@ shouldn't be moved back.)")
          '(2 'web-mode-variable-name-face))
    ))
 
+(defvar web-mode-artanis-font-lock-keywords
+  (list
+   (cons (concat "\\_<\\(" web-mode-artanis-keywords  "\\)\\_>") '(0 'web-mode-keyword-face))
+   (cons (concat "\\_<\\(" web-mode-artanis-constants "\\)\\_>") '(0 'web-mode-constant-face))
+   '("(define[*]? (\\([[:alnum:]-:]+\\)"     1 'web-mode-function-name-face)
+   '("\\(#:[[:alnum:]-:_!#$%^&*=+/?<>.]+\\)" 1 'web-mode-builtin-face)
+   ))
+
 (defvar web-mode-php-font-lock-keywords
   (list
    (cons (concat "\\_<\\(" web-mode-php-keywords "\\)\\_>") '(0 'web-mode-keyword-face))
@@ -2208,6 +2237,7 @@ shouldn't be moved back.)")
 
 (defvar web-mode-engines-font-lock-keywords
   '(("angular"          . web-mode-angular-font-lock-keywords)
+    ("artanis"          . web-mode-artanis-font-lock-keywords)
     ("blade"            . web-mode-blade-font-lock-keywords)
     ("cl-emb"           . web-mode-cl-emb-font-lock-keywords)
     ("closure"          . web-mode-closure-font-lock-keywords)


### PR DESCRIPTION
Adds support for snippets, file-extension, and code highlighting for Artanis (https://web-artanis.com/) template files (basically, Guile Scheme).

I'm not sure if the `lsp` engine is for all LISPs or specifically Common LISP but Artanis does have some particular features/syntax that's unique to it so I added a new engine for it.

The one thing I couldn't get working was the constants; seeing as the whole list is wrapped in `regexp-opt`, I would think Emacs would take good care of outfitting them to perfect regex. but the `#t` and `#f` values don't get properly highlighted, at all, by font-lock and I'm not sure why. I think it may be the pound character causing things not to work.