### PR TITLE
Added syntax awareness to vue-specific attributes

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -1259,7 +1259,7 @@ Must be used in conjunction with web-mode-enable-block-face."
    '("template-toolkit" . "\\[%.\\|%%#")
    '("underscore"       . "<%")
    '("velocity"         . "#[[:alpha:]#*]\\|$[[:alpha:]!{]")
-   '("vue"              . "{{")
+   '("vue"              . "{{\\|\\(:\\|@\\)[-a-zA-Z]+=\"")
    '("web2py"           . "{{")
    '("xoops"            . "<{[[:alpha:]#$/*\"]")
    )
@@ -3052,9 +3052,15 @@ another auto-completion with different ac-sources (e.g. ac-php)")
           ) ;angular
 
          ((string= web-mode-engine "vue")
-          (setq closing-string "}}"
-                delim-open "{{"
-                delim-close "}}")
+          (cond
+           ((string-match-p "\\(:\\|@\\)[-a-zA-Z]+=\"" tagopen)
+            (setq closing-string "\""
+                  delim-open tagopen
+                  delim-close "\""))
+           ((string= tagopen "{{")
+            (setq closing-string "}}"
+                  delim-open "{{"
+                  delim-close "}}")))
           ) ;vue
 
          ((string= web-mode-engine "mason")

--- a/web-mode.el
+++ b/web-mode.el
@@ -1259,7 +1259,7 @@ Must be used in conjunction with web-mode-enable-block-face."
    '("template-toolkit" . "\\[%.\\|%%#")
    '("underscore"       . "<%")
    '("velocity"         . "#[[:alpha:]#*]\\|$[[:alpha:]!{]")
-   '("vue"              . "{{\\|\\(:\\|@\\)[-a-zA-Z]+=\"")
+   '("vue"              . "{{\\|[:@][-[:alpha:]]+=\"")
    '("web2py"           . "{{")
    '("xoops"            . "<{[[:alpha:]#$/*\"]")
    )
@@ -3053,7 +3053,7 @@ another auto-completion with different ac-sources (e.g. ac-php)")
 
          ((string= web-mode-engine "vue")
           (cond
-           ((string-match-p "\\(:\\|@\\)[-a-zA-Z]+=\"" tagopen)
+           ((string-match-p "[:@][-[:alpha:]]+=\"" tagopen)
             (setq closing-string "\""
                   delim-open tagopen
                   delim-close "\""))


### PR DESCRIPTION
With Vue it is often appropriate to include JavaScript in certain attribute tags, however web-mode does not currently do syntax highlighting for these tags.

https://gist.github.com/dane-johnson/4498927365dd14c29c2088ff0a77575b
Github's syntax highlighting gets it right!