### PR TITLE
Fix "Search failed" after "${" in Velocity

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -3473,7 +3473,7 @@ another auto-completion with different ac-sources (e.g. ac-php)")
       (forward-char))
     (cond
      ((member (char-after) '(?\{))
-      (search-forward "}"))
+      (search-forward "}" nil t))
      ((looking-at-p "def \\|define ")
       (search-forward ")" (line-end-position) t))
      (t


### PR DESCRIPTION
Steps to reproduce:

1. Open a new web-mode buffer with the following contents:
    ```html
   <html><body>

    </body></html>
    ```
2. <kbd>M-x</kbd> `web-mode-set-engine` <kbd>RET</kbd> `velocity` <kbd>RET</kbd>
3. Move point to the blank line in the `body` and type `${`

Expected result: `${|}` with cursor at `|`

Observed result: `${|` with cursor at `|`, a message in `*Messages*` reading `web-mode-velocity-skip: Search failed: "}"`, and basically everything having to do with opening/closing tags breaks in the buffer until I revert the buffer

I am *guessing* that having `noerror` be nil in the `search-forward` call here was an oversight, so this commit passes `t` for `noerror`.