### PR TITLE
Add new Rails 6 ERB helpers

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -1569,6 +1569,7 @@ shouldn't be moved back.)")
       "session" "t" "telephone_field" "telephone_field_tag"
       "time_tag" "translate" "url_field" "url_field_tag"
       "url_options" "video_path" "video_tag" "simple_form_for"
+      "javascript_pack_tag" "stylesheet_pack_tag" "csp_meta_tag"
 
       ))))
 


### PR DESCRIPTION
Webpacker, the default JavaScript compiler for Rails 6, [has introduced](https://github.com/rails/webpacker#usage) the `javascript_pack_tag` and `stylesheet_pack_tag` ERB helpers.

Rails 6 has also added the [`csp_meta_tag`](https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/CspHelper.html#method-i-csp_meta_tag) ERB helper.

This PR adds all three helpers to `web-mode-erb-builtins`.