### PR TITLE
Fix for Artanis Engine–File-Regexp Conflict with Smarty

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -909,7 +909,7 @@ Must be used in conjunction with web-mode-enable-block-face."
 (defvar web-mode-engine-file-regexps
   '(("angular"          . "\\.component.html\\'")
     ("archibus"         . "\\.axvw\\'")
-    ;;("artanis"          . "\\.tpl\\'") // conflict with smarty, see below
+    ("artanis"          . "\\.html\\.tpl\\'")
     ("asp"              . "\\.asp\\'")
     ("aspx"             . "\\.as[cp]x\\'")
     ("blade"            . "\\.blade\\.php\\'")


### PR DESCRIPTION
From what I've seen, it seems that Smarty uses ".tpl" extensions strictly while, I believe, Artanis generally uses ".html.tpl".

As such, suggesting this as a possible solution to avoid conflict?