### PR TITLE
[WIP] Add class and tag faces

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -459,6 +459,16 @@ See web-mode-block-face."
   "Face for CSS rules."
   :group 'web-mode-faces)
 
+(defface web-mode-css-selector-class-face
+  '((t :inherit font-lock-keyword-face))
+  "Face for CSS class rules."
+  :group 'web-mode-faces)
+
+(defface web-mode-css-selector-tag-face
+  '((t :inherit font-lock-keyword-face))
+  "Face for CSS tag rules."
+  :group 'web-mode-faces)
+
 (defface web-mode-css-pseudo-class-face
   '((t :inherit font-lock-builtin-face))
   "Face for CSS pseudo-classes."
@@ -1820,7 +1830,8 @@ shouldn't be moved back.)")
          '(0 'web-mode-css-at-rule-face))
    '("\\_<\\(all\|braille\\|embossed\\|handheld\\|print\\|projection\\|screen\\|speech\\|tty\\|tv\\|and\\|or\\)\\_>"
      1 'web-mode-keyword-face)
-   '("[^,]+" 0 'web-mode-css-selector-face)
+   '("\\.[^ ,]+" 0 'web-mode-css-selector-class-face)
+   '("[^,]+" 0 'web-mode-css-selector-tag-face)
    (cons (concat ":\\([ ]*[[:alpha:]][^,{]*\\)") '(0 'web-mode-css-pseudo-class-face t t))
    ))
 


### PR DESCRIPTION
Hello, I've added two new faces: `web-mode-css-selector-class-face` and `web-mode-css-selector-tag-face`.

I'd like to enhance `web-mode`'s css highlighting abilities, eventually being able to highlight syntax like so:

![image](https://user-images.githubusercontent.com/1888338/76975369-be49a480-6932-11ea-94c3-cf75fb8a7572.png)

At the moment I just added the ability to differenciate between class selectors (`.myclass { ...}`) and tag selectors (`div {...}`).

Ideally I would add some more rules, and I'm sure what I already added could be improved, it's not perfect yet but a proof of concept. Before continuing working on this however, I'd like to know if a change like this is welcomed and whether or not I should keep going with this.

Cheers.