### PR TITLE
Elixir font lock improvements

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -1412,6 +1412,7 @@ shouldn't be moved back.)")
    (append
     (cdr (assoc "elixir" web-mode-extra-builtins))
     '("case" "cond" "for" "if" "quote" "raise" "receive" "send"
+      "fn" "do" "end" "after" "else" "rescue" "catch" "end" "not" "and" "or" "when" "in"
       "super" "throw" "try" "unless" "unquote" "unquote_splicing"
       "with"
       ))))
@@ -1422,12 +1423,6 @@ shouldn't be moved back.)")
    (append
     (cdr (assoc "elixir" web-mode-extra-constants))
     '("true" "false"))))
-
-(defvar web-mode-elixir-keywords
-  (regexp-opt
-   (append
-    (cdr (assoc "elixir" web-mode-extra-keywords))
-    '("fn" "do" "end" "after" "else" "rescue" "catch" "if" "end" "not" "and" "or" "when" "in"))))
 
 (defvar web-mode-erlang-constants
   (regexp-opt
@@ -2275,8 +2270,7 @@ shouldn't be moved back.)")
 
 (defvar web-mode-elixir-font-lock-keywords
   (list
-   (cons (concat "\\_<\\(" web-mode-elixir-builtins "\\)\\_>") '(0 'web-mode-keyword-face))
-   (cons (concat "\\_<\\(" web-mode-elixir-keywords "\\)\\_>") '(0 'web-mode-keyword-face))
+   (cons (concat "\\_<\\(" web-mode-elixir-builtins "\\)\\_>") '(0 'web-mode-builtin-face))
    (cons (concat "\\_<\\(" web-mode-elixir-constants "\\)\\_>") '(0 'web-mode-constant-face))
    '("@\\([[:alnum:]_]+\\)" 0 'web-mode-variable-name-face)
    '("[ ]\\(:[[:alnum:]-_]+\\)" 1 'web-mode-symbol-face)

--- a/web-mode.el
+++ b/web-mode.el
@@ -1407,22 +1407,18 @@ shouldn't be moved back.)")
     (cdr (assoc "python" web-mode-extra-constants))
     '("True" "False" "None" "__debug__" "NotImplemented" "Ellipsis"))))
 
-(defvar web-mode-elixir-builtins
+(defvar web-mode-elixir-keywords
   (regexp-opt
    (append
-    (cdr (assoc "elixir" web-mode-extra-builtins))
-    '("case" "cond" "for" "if" "quote" "raise" "receive" "send"
-      "fn" "do" "end" "after" "else" "rescue" "catch" "end" "not" "and" "or" "when" "in"
-      "super" "throw" "try" "unless" "unquote" "unquote_splicing"
-      "with"
-      ))))
+    (cdr (assoc "elixir" web-mode-extra-keywords))
+    '("do" "end" "case" "bc" "lc" "for" "if" "cond" "with" "unless" "try" "receive" "fn" "defmodule" "defprotocol" "defimpl" "defrecord" "defrecordp" "defstruct" "defdelegate" "defcallback" "defexception" "defoverridable" "defguard" "defgaurdp" "exit" "after" "rescue" "catch" "else" "raise" "throw" "quote" "unquote" "super" "when" "and" "or" "not" "in"))))
 
 
 (defvar web-mode-elixir-constants
   (regexp-opt
    (append
     (cdr (assoc "elixir" web-mode-extra-constants))
-    '("true" "false"))))
+    '("nil" "true" "false"))))
 
 (defvar web-mode-erlang-constants
   (regexp-opt
@@ -2270,8 +2266,9 @@ shouldn't be moved back.)")
 
 (defvar web-mode-elixir-font-lock-keywords
   (list
-   (cons (concat "\\_<\\(" web-mode-elixir-builtins "\\)\\_>") '(0 'web-mode-builtin-face))
+   (cons (concat "\\_<\\(" web-mode-elixir-keywords "\\)\\_>") '(0 'web-mode-builtin-face))
    (cons (concat "\\_<\\(" web-mode-elixir-constants "\\)\\_>") '(0 'web-mode-constant-face))
+   '("def[ ]+\\([[:alnum:]_]+\\)" 1 'web-mode-function-name-face)
    '("@\\([[:alnum:]_]+\\)" 0 'web-mode-variable-name-face)
    '("[ ]\\(:[[:alnum:]-_]+\\)" 1 'web-mode-symbol-face)
    ))

--- a/web-mode.el
+++ b/web-mode.el
@@ -1407,6 +1407,28 @@ shouldn't be moved back.)")
     (cdr (assoc "python" web-mode-extra-constants))
     '("True" "False" "None" "__debug__" "NotImplemented" "Ellipsis"))))
 
+(defvar web-mode-elixir-builtins
+  (regexp-opt
+   (append
+    (cdr (assoc "elixir" web-mode-extra-builtins))
+    '("case" "cond" "for" "if" "quote" "raise" "receive" "send"
+                          "super" "throw" "try" "unless" "unquote" "unquote_splicing"
+                          "with"
+      ))))
+
+
+(defvar web-mode-elixir-constants
+  (regexp-opt
+   (append
+    (cdr (assoc "elixir" web-mode-extra-constants))
+    '("true" "false"))))
+
+(defvar web-mode-elixir-keywords
+  (regexp-opt
+   (append
+    (cdr (assoc "elixir" web-mode-extra-keywords))
+    '("fn" "do" "end" "after" "else" "rescue" "catch" "if" "end" "not" "and" "or" "when" "in"))))
+
 (defvar web-mode-erlang-constants
   (regexp-opt
    (append
@@ -2251,6 +2273,15 @@ shouldn't be moved back.)")
    (cons (concat "\\_<\\(" web-mode-python-keywords "\\)\\_>") '(0 'web-mode-keyword-face))
    ))
 
+(defvar web-mode-elixir-font-lock-keywords
+  (list
+   (cons (concat "\\_<\\(" web-mode-elixir-builtins "\\)\\_>") '(0 'web-mode-builtin-face))
+   (cons (concat "\\_<\\(" web-mode-elixir-keywords "\\)\\_>") '(0 'web-mode-keyword-face))
+   (cons (concat "\\_<\\(" web-mode-elixir-constants "\\)\\_>") '(0 'web-mode-constant-face))
+   '("@\\([[:alnum:]_]+\\)" 0 'web-mode-variable-name-face)
+   '("[ ]\\(:[[:alnum:]-_]+\\)" 1 'web-mode-symbol-face)
+   ))
+
 (defvar web-mode-erlang-font-lock-keywords
   (list
    (cons (concat "\\_<\\(" web-mode-erlang-keywords "\\)\\_>") '(0 'web-mode-keyword-face))
@@ -2355,7 +2386,7 @@ shouldn't be moved back.)")
     ("closure"          . web-mode-closure-font-lock-keywords)
     ("ctemplate"        . web-mode-ctemplate-font-lock-keywords)
     ("dust"             . web-mode-dust-font-lock-keywords)
-    ("elixir"           . web-mode-erlang-font-lock-keywords)
+    ("elixir"           . web-mode-elixir-font-lock-keywords)
     ("ejs"              . web-mode-ejs-font-lock-keywords)
     ("erb"              . web-mode-erb-font-lock-keywords)
     ("expressionengine" . web-mode-expressionengine-font-lock-keywords)

--- a/web-mode.el
+++ b/web-mode.el
@@ -1412,8 +1412,8 @@ shouldn't be moved back.)")
    (append
     (cdr (assoc "elixir" web-mode-extra-builtins))
     '("case" "cond" "for" "if" "quote" "raise" "receive" "send"
-                          "super" "throw" "try" "unless" "unquote" "unquote_splicing"
-                          "with"
+      "super" "throw" "try" "unless" "unquote" "unquote_splicing"
+      "with"
       ))))
 
 

--- a/web-mode.el
+++ b/web-mode.el
@@ -2275,7 +2275,7 @@ shouldn't be moved back.)")
 
 (defvar web-mode-elixir-font-lock-keywords
   (list
-   (cons (concat "\\_<\\(" web-mode-elixir-builtins "\\)\\_>") '(0 'web-mode-builtin-face))
+   (cons (concat "\\_<\\(" web-mode-elixir-builtins "\\)\\_>") '(0 'web-mode-keyword-face))
    (cons (concat "\\_<\\(" web-mode-elixir-keywords "\\)\\_>") '(0 'web-mode-keyword-face))
    (cons (concat "\\_<\\(" web-mode-elixir-constants "\\)\\_>") '(0 'web-mode-constant-face))
    '("@\\([[:alnum:]_]+\\)" 0 'web-mode-variable-name-face)


### PR DESCRIPTION
## Background
Thank you for such an awesome library. I would love to refine this a bit more but my elisp is not the best. 

There are several improvements I think I can make to this if you could explain a bit on how I could port over something [like this from elixir-mode](https://github.com/elixir-editors/emacs-elixir/blob/master/elixir-mode.el#L103-L109). I am not sure how to translate that format of regex into one that would work with web-mode.

## Changes

* Make `web-mode-elixir-*` depend on it's own functions rather than only extending `web-mode-erlang-*` functions.