### PR TITLE
fix uncomment for tsx and jsx

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -5625,7 +5625,10 @@ another auto-completion with different ac-sources (e.g. ac-php)")
          ) ;cond
 
         (when (and beg (>= reg-end (point)) token-type)
-          (put-text-property beg (point) 'part-token token-type)
+          (if (and (string= content-type "jsx")
+                   (eq ?\{ (char-before beg)))
+              (put-text-property (1- beg) (point) 'part-token token-type)
+            (put-text-property beg (point) 'part-token token-type))
           (cond
            ((eq token-type 'comment)
             (put-text-property beg (1+ beg) 'syntax-table (string-to-syntax "<"))


### PR DESCRIPTION
For uncommenting, as far as I understand, we rely on some text properties with
value as 'comment, to determine the beginning of a comment. But this won't work
well for jsx elements ({/* ... */}). Because `web-mode-part-scan` only marks
'comment property starting from `/` thus missing `{`.

This PR makes sure `web-mode-part-scan` to include `{` in commenting, so
uncommenting will work. This is however not a complete fix but it would cover
most of the use cases.