### PR TITLE
Allow extra expanders to override standard ones

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -11600,7 +11600,7 @@ Prompt user if TAG-NAME isn't provided."
                         (not (get-text-property (1- pos) 'part-side))))
                (not (get-text-property (1- pos) 'block-side))
                )
-      (setq expanders (append web-mode-expanders web-mode-extra-expanders))
+      (setq expanders (append web-mode-extra-expanders web-mode-expanders))
       (let ((i 0) pair (l (length expanders)))
         (setq chunk (buffer-substring-no-properties (- pos 2) pos))
         ;;(message "%S" chunk)


### PR DESCRIPTION
This way, we can replace the default expanders by custom ones.