### PR TITLE
Actually enable lexical-binding

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -1,5 +1,4 @@
-;;; web-mode.el --- major mode for editing web templates
-;;; -*- coding: utf-8; lexical-binding: t; -*-
+;;; web-mode.el --- major mode for editing web templates -*- lexical-binding: t; -*-
 
 ;; Copyright 2011-2020 François-Xavier Bois
 


### PR DESCRIPTION
Current web-mode doesn't use `lexical-binding` According to the docstring of `lexical-binding`

```
Non-nil means that the code in the current buffer should be evaluated
with lexical binding.
This variable is automatically set from the file variables of an
interpreted Lisp file read using load.  Unlike other file local
variables, this must be set in the first line of a file.
```

We should place it to the first line.