### PR TITLE
[ Elixir ] Match atoms, variables and function names before keywords

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -2277,11 +2277,11 @@ shouldn't be moved back.)")
 
 (defvar web-mode-elixir-font-lock-keywords
   (list
-   (cons (concat "\\_<\\(" web-mode-elixir-keywords "\\)\\_>") '(0 'web-mode-builtin-face))
-   (cons (concat "\\_<\\(" web-mode-elixir-constants "\\)\\_>") '(0 'web-mode-constant-face))
-   '("def[ ]+\\([[:alnum:]_]+\\)" 1 'web-mode-function-name-face)
    '("@\\([[:alnum:]_]+\\)" 0 'web-mode-variable-name-face)
    '("[ ]\\(:[[:alnum:]-_]+\\)" 1 'web-mode-symbol-face)
+   '("def[ ]+\\([[:alnum:]_]+\\)" 1 'web-mode-function-name-face)
+   (cons (concat "\\_<\\(" web-mode-elixir-keywords "\\)\\_>") '(0 'web-mode-builtin-face))
+   (cons (concat "\\_<\\(" web-mode-elixir-constants "\\)\\_>") '(0 'web-mode-constant-face))
    ))
 
 (defvar web-mode-erlang-font-lock-keywords


### PR DESCRIPTION
When using a @for variable, the font is wrong. Similarly with :for etc..

Moving the keyword and constants down the list means it will match it
first. It also makes it not jump colours when choosing variable names
like @form between r and m.
