### PR TITLE
Respect font-lock-dont-widen during region extension

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -2836,6 +2836,9 @@ another auto-completion with different ac-sources (e.g. ac-php)")
   (when (or (null web-mode-change-end) (> font-lock-end web-mode-change-end))
     (when web-mode-trace (message "extend-region: font-lock-end(%S) > web-mode-change-end(%S)" font-lock-end web-mode-change-end))
     (setq web-mode-change-end font-lock-end))
+  (when font-lock-dont-widen
+    (setq web-mode-change-beg (max web-mode-change-beg (point-min))
+          web-mode-change-end (min web-mode-change-end (point-max))))
   (let ((region (web-mode-scan web-mode-change-beg web-mode-change-end)))
     (when region
       ;;(message "region: %S" region)


### PR DESCRIPTION
I have a number of reports in polymode where web-mode breaks when used as inner mode (ex polymode/polymode#308, polymode/polymode#270). 

I have tracked it down to web-mode scanning on a region wider than the current narrowing. It turned out current scanning machinery does not respect `font-lock-dont-widen`, hence the fix. 

It looks to me that  `web-mode-scan` itself should check for narrowing before running the scans on a wider region but I haven't touched that part because I am not familiar with the code base. 