### PR TITLE
fixed: web-mode-comment-indent-new-line

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -10936,7 +10936,14 @@ Prompt user if TAG-NAME isn't provided."
      (t
       (newline 1)
       (indent-line-to (plist-get ctx :col))
-      (insert (concat (plist-get ctx :prefix) " ")))
+      (let ((prefix (plist-get ctx :prefix)))
+        (insert
+         (concat prefix
+                 ;; Check if the comment ends with a space, and if not, insert one.
+                 (if
+                     (string-equal (substring prefix -1 (length prefix)) " ")
+                     ""
+                   " ")))))
      ) ;cond
     ))
 

--- a/web-mode.el
+++ b/web-mode.el
@@ -10936,7 +10936,7 @@ Prompt user if TAG-NAME isn't provided."
      (t
       (newline 1)
       (indent-line-to (plist-get ctx :col))
-      (insert (concat (plist-get ctx :prefix) "")))
+      (insert (concat (plist-get ctx :prefix) " ")))
      ) ;cond
     ))
 


### PR DESCRIPTION
Like the behavior of the original `comment-indent-new-line` it replaces, it inserts a space when generating a new comment line.
I thought the behavior before the modification was a matter of preference and that I would have to provide a custom one.
However, when I actually looked at the source code, I found that it seemed meaningless to bother to concat an empty string.
Therefore, I decided that I simply forgot to insert a space.