### PR TITLE
Recognize new TypeScript file extensions

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -998,7 +998,7 @@ Must be used in conjunction with web-mode-enable-block-face."
 (defvar web-mode-content-types
   '(("css"        . "\\.\\(s?css\\|css\\.erb\\)\\'")
     ("javascript" . "\\.\\([mc]?js\\|js\\.erb\\)\\'")
-    ("typescript" . "\\.\\(ts\\|ts\\.erb\\)\\'")
+    ("typescript" . "\\.\\([mc]?ts\\|ts\\.erb\\)\\'")
     ("json"       . "\\.\\(api\\|json\\|jsonld\\)\\'")
     ("jsx"        . "\\.[jt]sx\\'")
     ("xml"        . "\\.xml\\'")


### PR DESCRIPTION
Hi.

TypeScript 4.7 supports `.cts` and `.mts` file extensions as counterparts of `.cjs` and `.mjs`.

This patch modifies `web-mode-content-types` so that the files with those new extensions are handled as TypeScript.

ref: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#new-file-extensions