### PR TITLE
Adds blocktranslate/endblocktranslate to web-mode-django-control-blocks

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -1855,7 +1855,7 @@ shouldn't be moved back.)")
    '(
 
      "assets" "autoescape"
-     "block" "blocktrans"
+     "block" "blocktrans" "blocktranslate"
      "cache" "call" "capture" "comment"
      "draw"
      "embed"
@@ -1870,7 +1870,7 @@ shouldn't be moved back.)")
      "with"
 
      "endassets" "endautoescape"
-     "endblock" "endblocktrans"
+     "endblock" "endblocktrans" "endblocktranslate"
      "endcache" "endcall" "endcapture" "endcomment"
      "draw"
      "endembed"


### PR DESCRIPTION
Since Django 3.1 the tags `blocktranslate` and `endblocktranslate` can be used instead of `blocktrans` and `endblocktrans`.

see https://docs.djangoproject.com/en/5.0/releases/3.1/#templates

This PR just adds these new tags to `web-mode-django-control-blocks`