### PR TITLE
safe local variables should be considered safe when autoloaded

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -71,49 +71,58 @@
   "Html attribute indentation level."
   :type '(choice (integer :tags "Number of spaces")
           (const :tags "Default" nil))
-  :safe #'(lambda (v) (or (integerp v) (booleanp v)))
   :group 'web-mode)
+;;;###autoload
+(put 'web-mode-attr-indent-offset
+     'safe-local-variable #'(lambda (v) (or (integerp v) (booleanp v))))
 
 (defcustom web-mode-attr-value-indent-offset nil
   "Html attribute value indentation level."
   :type '(choice (integer :tags "Number of spaces")
           (const :tags "Default" nil))
-  :safe #'(lambda (v) (or (integerp v) (booleanp v)))
   :group 'web-mode)
+;;;###autoload
+(put 'web-mode-attr-value-indent-offset
+     'safe-local-variable #'(lambda (v) (or (integerp v) (booleanp v))))
 
 (defcustom web-mode-markup-indent-offset
   (if (and (boundp 'standard-indent) standard-indent) standard-indent 2)
   "Html indentation level."
   :type 'integer
-  :safe #'integerp
   :group 'web-mode)
+;;;###autoload
+(put 'web-mode-markup-indent-offset 'safe-local-variable #'integerp)
 
 (defcustom web-mode-markup-comment-indent-offset
   5
   "Html comment indentation level."
   :type 'integer
-  :safe #'integerp
   :group 'web-mode)
+;;;###autoload
+(put 'web-mode-markup-comment-indent-offset 'safe-local-variable #'integerp)
 
 (defcustom web-mode-css-indent-offset
   (if (and (boundp 'standard-indent) standard-indent) standard-indent 2)
   "CSS indentation level."
   :type 'integer
-  :safe #'integerp
   :group 'web-mode)
+;;;###autoload
+(put 'web-mode-css-indent-offset 'safe-local-variable #'integerp)
 
 (defcustom web-mode-code-indent-offset
   (if (and (boundp 'standard-indent) standard-indent) standard-indent 2)
   "Code (javascript, php, etc.) indentation level."
   :type 'integer
-  :safe #'integerp
   :group 'web-mode)
+;;;###autoload
+(put 'web-mode-code-indent-offset 'safe-local-variable #'integerp)
 
 (defcustom web-mode-sql-indent-offset 4
   "Sql (inside strings) indentation level."
   :type 'integer
-  :safe #'integerp
   :group 'web-mode)
+;;;###autoload
+(put 'web-mode-sql-indent-offset 'safe-local-variable #'integerp)
 
 (defcustom web-mode-enable-css-colorization (display-graphic-p)
   "In a CSS part, set background according to the color: #xxx, rgb(x,x,x)."


### PR DESCRIPTION
I have an HTML file with the following file local variables:

``` html
<!-- Local Variables:
     web-mode-code-indent-offset: 1
     End: -->
```

If web-mode is already required, visiting this file is just fine. However, if web-mode is autoloaded, then Emacs thinks this setting is unsafe, despite it being marked as :safe.

``` elisp
(defcustom web-mode-code-indent-offset
  :safe #'integerp)
```

This is because Emacs doesn’t know that the variable is safe until it loads the package. In order to avoid this, we replace the :safe property with an autoload cookie that assigns its safety predicate:

``` elisp
;;;###autoload
(put 'web-mode-code-indent-offset 'safe-local-variable #'integerp)
```

Fixes fxbois/web-mode#1302.