### PR TITLE
Fontify capitalized tags as custom tags

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -5478,7 +5478,8 @@ Also return non-nil if it is the command `self-insert-command' is remapped to."
         ;;(message "%S: %S (%S %S)" (point) (match-string-no-properties 0) reg-beg reg-end)
 
         (setq flags 0
-              tname (downcase (match-string-no-properties 1))
+              tnameraw (match-string-no-properties 1)
+              tname (downcase tnameraw)
               char (aref tname 0)
               tbeg (match-beginning 0)
               tend nil
@@ -5507,7 +5508,9 @@ Also return non-nil if it is the command `self-insert-command' is remapped to."
 
           ((not (member char '(?\! ?\?)))
            (cond
-             ((string-match-p "-" tname)
+            ((or (string-match-p "-" tname)
+                 (let ((case-fold-search nil))
+                   (string-match-p "^/?[[:upper:]]" tnameraw)))
               (setq flags (logior flags 2)))
              ;;((string-match-p ":" tname)
              ;; (setq flags (logior flags 32)))


### PR DESCRIPTION
In Vue templates it is common to case component tags as PascalCase, sometimes people hyphenate the name, which web-mode already fontifies with `web-mode-html-tag-custom-face`.

I wanted this fontification to also apply to the components in my codebase, which are PascalCase. I accomplished this by editing the relevant `web-mode-scan-elements` condition with a case sensitive string match.

This requires "duplicating" the `tname` variable, as it is already downcased at the top of the let expression.

Currently this sets the same flag as for hyphenated tags, which works for my use-case, but it might be nice to set a different flag, or make this feature optional somehow.