### PR TITLE
Allow ‘.’ in Vue attributes

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -3830,7 +3830,7 @@ Also return non-nil if it is the command `self-insert-command' is remapped to."
 
           ((string= web-mode-engine "vue")
            (cond
-             ((string-match-p "[:@][-[:alpha:]]+=\"" tagopen)
+             ((string-match-p "[:@][-[:alpha:].]+=\"" tagopen)
               (setq closing-string "\""
                     delim-open tagopen
                     delim-close "\""))


### PR DESCRIPTION
This adds support for attributes like ‘@click.single="..."’ or ‘@submit.prevent’ which were not fontified as Vue-specific attributes before.