### PR TITLE
font-lock-defaults fix for web-mode derived mode crashing on quote

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -2892,7 +2892,7 @@ another auto-completion with different ac-sources (e.g. ac-php)")
           comment-start "<!--"
           fill-paragraph-function 'web-mode-fill-paragraph
           ;;font-lock-defaults '(web-mode-font-lock-keywords t)
-          font-lock-defaults '('(web-mode-fontify) t)
+          font-lock-defaults '(web-mode-fontify t)
           font-lock-extend-region-functions '(web-mode-extend-region)
           font-lock-support-mode nil
           font-lock-unfontify-region-function 'web-mode-unfontify-region


### PR DESCRIPTION
In Emacs 30.x:

Font-Locks `font-lock-eval-keywords` crashes evaluating the `funcall` from web-mode's derived-mode definition where: `font-lock-defaults` is set to:
```lisp
  '(web-mode-fontify) t
```
To resolve the issue, the value needs to be changed to `eval` successfully