### PR TITLE
add wildcard support for `web-mode-indentless-attributes`

### DIFF
--- a/web-mode.el
+++ b/web-mode.el
@@ -5675,6 +5675,17 @@ Also return non-nil if it is the command `self-insert-command' is remapped to."
 ;; (6)value-uq (7)value-sq (8)value-dq (9)value-bq : jsx attr={}
 ;; (10)value-block
 
+(defun web-mode--indentless-attribute-p (attr)
+  "Return t if ATTR is in `web-mode-indentless-attributes'.
+  Handles wildcards where '*' matches any suffix."
+  (let ((found nil))
+    (dolist (pattern web-mode-indentless-attributes found)
+      (if (string-suffix-p "*" pattern)
+          (when (string-prefix-p (substring pattern 0 -1) attr)
+            (setq found t))
+        (when (string= pattern attr)
+          (setq found t))))))
+
 (defun web-mode-attr-skip (limit)
 
   (let ((tag-flags 0) (attr-flags 0) (continue t) (attrs 0) (brace-depth 0)
@@ -5766,7 +5777,7 @@ Also return non-nil if it is the command `self-insert-command' is remapped to."
                name-end (1- pos))
          (setq state 4)
          (setq attr (buffer-substring-no-properties name-beg (1+ name-end)))
-         (when (and web-mode-indentless-attributes (member (downcase attr) web-mode-indentless-attributes))
+         (when (and web-mode-indentless-attributes (web-mode--indentless-attribute-p (downcase attr)))
            (setq attr-flags (logior attr-flags 8)))
          )
 


### PR DESCRIPTION
Noted issue with JS libraries / frameworks like Datastar and AlpineJS where attribute value non-indenting rules cannot be easily applied to attributes that use modifiers such as [`data-on:<eventname>`](https://alpinejs.dev/directives/on) or [`x-on:<eventname>`](https://alpinejs.dev/directives/on) as only string matches are looked from `web-mode-indentless-attributes`.

With this edit, wildcard postfix is allowed for more flexible matching e.g. following which should match attributes starting with `data-on:`:

```emacs-lisp
(setq web-mode-indentless-attributes
      '("onclick" "onmouseover" "onmouseout" "onsubmit" "data-on:*"))
```

With quick testing this seems to work but am evaluating it further currently. Is this sort of feature something that would be feasible to include in web-mode @fxbois ?


Test setup / demo (Emacs 30.1):

config.el
```emacs-lisp
(setq-default indent-tabs-mode nil)
(setopt inhibit-splash-screen t)

;; Load the patched web-mode.el
(load "/home/user/Desktop/web-mode-attr-wildcard/web-mode/web-mode.el")
(add-to-list 'auto-mode-alist '("\\.html?\\'" . web-mode))

;; Add custom rule to match data-on: attribute
(setq web-mode-indentless-attributes
      '("onclick" "onmouseover" "onmouseout" "onsubmit" "data-on:*"))
```

example.html
```html
<div onclick="just {
                testing
              }"
     data-on:click="just {
                      testing
                    }"
     data-not-click="just {
              testing
              }"></div>
```
- onclick keeps manual indent (as it does by default)
- data-on:click follows same rule (matched by wildcard)
- data-not-click gets auto indented (normal behavior)

Run: `emacs -q -l ./config.el ./example.html`
